### PR TITLE
Add a Codacy badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # parthenon
 
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/3c7f326d05b34929a847657a9674f524)](https://app.codacy.com/gh/lanl/parthenon?utm_source=github.com&utm_medium=referral&utm_content=lanl/parthenon&utm_campaign=Badge_Grade_Settings)
+
 Parthenon AMR infrastructure 
 
 # Required Dependencies


### PR DESCRIPTION
Literally adds the github badge for Codacy. Why? Well to advertise the quality using a third party metric. 