### PR TITLE
Fix Metadata::IsSet, operator==, and operator!=

### DIFF
--- a/src/interface/Metadata.cpp
+++ b/src/interface/Metadata.cpp
@@ -36,7 +36,7 @@ namespace parthenon {
 namespace internal {
 
 class UserMetadataState {
-public:
+ public:
     UserMetadataState() {
 #define PARTHENON_INTERNAL_FOR_FLAG(name) \
     flag_name_map_.push_back(#name);
@@ -56,19 +56,20 @@ public:
         auto const flag = flag_name_map_.size();
         flag_names_.insert(name);
         flag_name_map_.push_back(std::move(name));
-        return MetadataFlag((int)flag);
+        return MetadataFlag(static_cast<int>(flag));
     }
 
     std::string const &FlagName(MetadataFlag flag) {
         return flag_name_map_.at(flag.flag_);
     }
-private:
+
+ private:
     std::vector<std::string> flag_name_map_;
     std::unordered_set<std::string> flag_names_;
 };
 
-}
-}
+} // namespace internal
+} // namespace parthenon
 
 parthenon::internal::UserMetadataState metadata_state;
 

--- a/src/interface/Metadata.hpp
+++ b/src/interface/Metadata.hpp
@@ -21,14 +21,15 @@
 #include <tuple>
 #include <vector>
 
-/// The point of this macro is to generate code for each built-in flag using the 
+/// The point of this macro is to generate code for each built-in flag using the
 /// `PARTHENON_INTERNAL_FOR_FLAG` macro. This is to accomplish the following goals:
 /// - Generate a unique value for each flag using an enum
-/// - Wrap each value in a `MetadataFlag` type that can only be instantiated within parthenon
+/// - Wrap each value in a `MetadataFlag` type that can only be instantiated within
+///   parthenon
 /// - Make it possible to return a user-friendly string for each flag.
 ///
-/// Having this macro means you only need to add a new flag in one place and have each of these
-/// properties automatically be updated.
+/// Having this macro means you only need to add a new flag in one place and have each of
+/// these properties automatically be updated.
 #define PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG \
   /**  bit 0 is ignored */ \
   PARTHENON_INTERNAL_FOR_FLAG(Ignore) \
@@ -72,16 +73,17 @@
 namespace parthenon {
 
 namespace internal {
-  enum class MetadataInternal {
-    // declare all the internal flags in an enum so that their values are unique and kept up to date
+enum class MetadataInternal {
+  // declare all the internal flags in an enum so that their values are unique and kept
+  // up to date
 #define PARTHENON_INTERNAL_FOR_FLAG(name) name,
-    PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG
-    Max
+  PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG
+  Max
 #undef PARTHENON_INTERNAL_FOR_FLAG
-  };
+};
 
-  class UserMetadataState;
-}
+class UserMetadataState;
+} // namespace internal
 
 class Metadata;
 
@@ -100,7 +102,7 @@ class MetadataFlag {
   friend class Metadata;
   friend class internal::UserMetadataState;
 
-public:
+ public:
   constexpr bool operator==(MetadataFlag const &other) const {
     return flag_ == other.flag_;
   }
@@ -117,7 +119,8 @@ public:
     return flag_;
   }
 #endif
-private:
+
+ private:
   // MetadataFlag can only be instantiated by Metadata
   constexpr explicit MetadataFlag(int flag) : flag_(flag) {}
 
@@ -138,8 +141,8 @@ class Metadata {
   /// whether it sparse, etc.  This is designed to be easily extensible.
 
 
-  // this wraps all the built-in flags in the `MetadataFlag` type so that using these flags is
-  // type-safe.
+  // this wraps all the built-in flags in the `MetadataFlag` type so that using these
+  // flags is type-safe.
 #define PARTHENON_INTERNAL_FOR_FLAG(name) \
     constexpr static MetadataFlag name = \
       MetadataFlag(static_cast<int>(::parthenon::internal::MetadataInternal::name));
@@ -249,8 +252,8 @@ class Metadata {
     auto const &longer = a.bits_.size() > b.bits_.size() ? a.bits_ : b.bits_;
     for (auto i = max_bits; i < longer.size(); i++) {
       if (longer[i]) {
-        // Bits are default fault, so if any bit in the extraneous portion of the longer bit list is
-        // set, then it cannot be equal to a.
+        // Bits are default fault, so if any bit in the extraneous portion of the longer
+        // bit list is set, then it cannot be equal to a.
         return false;
       }
     }
@@ -271,7 +274,7 @@ class Metadata {
   void Associate(const std::string &name) { associated_ = name; }
   const std::string& getAssociated() const { return associated_; }
 
-private:
+ private:
   /// the attribute flags that are set for the class
   std::vector<bool> bits_;
   std::vector<int> shape_;
@@ -347,5 +350,5 @@ private:
             );
   }
 };
-}
+} // namespace parthenon
 #endif // INTERFACE_METADATA_HPP_

--- a/src/interface/Metadata.hpp
+++ b/src/interface/Metadata.hpp
@@ -248,9 +248,9 @@ class Metadata {
     auto const &a = *this;
 
     // Check extra bits are unset
-    auto const max_bits = std::max(a.bits_.size(), b.bits_.size());
+    auto const min_bits = std::min(a.bits_.size(), b.bits_.size());
     auto const &longer = a.bits_.size() > b.bits_.size() ? a.bits_ : b.bits_;
-    for (auto i = max_bits; i < longer.size(); i++) {
+    for (auto i = min_bits; i < longer.size(); i++) {
       if (longer[i]) {
         // Bits are default false, so if any bit in the extraneous portion of the longer
         // bit list is set, then it cannot be equal to a.
@@ -258,7 +258,7 @@ class Metadata {
       }
     }
 
-    for (size_t i = 0; i < max_bits; i++) {
+    for (size_t i = 0; i < min_bits; i++) {
       if (a.bits_[i] != b.bits_[i]) {
         return false;
       }

--- a/src/interface/Metadata.hpp
+++ b/src/interface/Metadata.hpp
@@ -252,7 +252,7 @@ class Metadata {
     auto const &longer = a.bits_.size() > b.bits_.size() ? a.bits_ : b.bits_;
     for (auto i = max_bits; i < longer.size(); i++) {
       if (longer[i]) {
-        // Bits are default fault, so if any bit in the extraneous portion of the longer
+        // Bits are default false, so if any bit in the extraneous portion of the longer
         // bit list is set, then it cannot be equal to a.
         return false;
       }

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -77,9 +77,25 @@ TEST_CASE("A Metadata struct is created", "[Metadata]") {
         REQUIRE(a == b);
     }
 
-    GIVEN("Two Different Metadata Structs Are Compared") {
-        Metadata a({Metadata::Cell}), b({Metadata::Face});
+    GIVEN("Two Metadata Structs Are Equivalent But Initialized Differently") {
+        Metadata a, b;
 
-        REQUIRE(a != b);
+        a.Set(Metadata::Cell);
+        a.Set(Metadata::Derived);
+
+        b.Set(Metadata::Derived);
+        b.Set(Metadata::Cell);
+
+        REQUIRE(a == b);
+    }
+
+    GIVEN("Two Different Metadata Structs Are Compared") {
+        REQUIRE(Metadata({Metadata::Cell}) != Metadata({Metadata::Face}));
+        REQUIRE(
+            Metadata({Metadata::Cell, Metadata::Derived}) !=
+            Metadata({Metadata::Face, Metadata::Derived}));
+        REQUIRE(
+            Metadata({Metadata::Cell, Metadata::Derived}) !=
+            Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy}));
     }
 }

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -41,3 +41,41 @@ TEST_CASE("A Metadata flag is allocated", "[Metadata]") {
         REQUIRE_THROWS_AS(Metadata::AllocateNewFlag("TestFlag"), std::runtime_error);
     }
 }
+
+TEST_CASE("A Metadata struct is created", "[Metadata]") {
+    GIVEN("A default Metadata struct") {
+        Metadata m;
+
+#define PARTHENON_INTERNAL_FOR_FLAG(name) REQUIRE(!m.IsSet(Metadata::name));
+    PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG
+#undef PARTHENON_INTERNAL_FOR_FLAG
+    }
+
+    GIVEN("Setting an arbitrary Metadata flag only sets that flag") {
+        Metadata m;
+        
+        m.Set(Metadata::FillGhost);
+
+
+#define PARTHENON_INTERNAL_FOR_FLAG(name) if (Metadata::name != Metadata::FillGhost) REQUIRE(!m.IsSet(Metadata::name));
+    PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG
+#undef PARTHENON_INTERNAL_FOR_FLAG
+
+        REQUIRE(m.IsSet(Metadata::FillGhost));
+    }
+
+    GIVEN("Two Equivalent Metadata Structs Are Compared") {
+        Metadata a({Metadata::Cell}), b({Metadata::Face});
+
+        b.Unset(Metadata::Face);
+        b.Set(Metadata::Cell);
+
+        REQUIRE(a == b);
+    }
+
+    GIVEN("Two Different Metadata Structs Are Compared") {
+        Metadata a({Metadata::Cell}), b({Metadata::Face});
+
+        REQUIRE(a != b);
+    }
+}

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -30,11 +30,14 @@ TEST_CASE("Built-in flags are registered", "[Metadata]") {
 TEST_CASE("A Metadata flag is allocated", "[Metadata]") {
     GIVEN("A User Flag") {
         auto const f = Metadata::AllocateNewFlag("TestFlag");
-        // Note: `parthenon::internal` is subject to change, and so this test may rightfully break
-        // later - this test needn't be maintained if so.
+        // Note: `parthenon::internal` is subject to change, and so this test may
+        // rightfully break later - this test needn't be maintained if so.
         //
-        // Checks that the first allocated flag is equal to `Max` - the final built-in flag + 1.
-        REQUIRE(f.InternalFlagValue() == static_cast<int>(parthenon::internal::MetadataInternal::Max));
+        // Checks that the first allocated flag is equal to `Max` - the final built-in
+        // flag + 1.
+        REQUIRE(
+            f.InternalFlagValue() ==
+                static_cast<int>(parthenon::internal::MetadataInternal::Max));
         REQUIRE("TestFlag" == f.Name());
 
         // It should throw an error if you try to allocate a new flag with the same name.
@@ -53,11 +56,12 @@ TEST_CASE("A Metadata struct is created", "[Metadata]") {
 
     GIVEN("Setting an arbitrary Metadata flag only sets that flag") {
         Metadata m;
-        
+
         m.Set(Metadata::FillGhost);
 
 
-#define PARTHENON_INTERNAL_FOR_FLAG(name) if (Metadata::name != Metadata::FillGhost) REQUIRE(!m.IsSet(Metadata::name));
+#define PARTHENON_INTERNAL_FOR_FLAG(name) \
+    if (Metadata::name != Metadata::FillGhost) REQUIRE(!m.IsSet(Metadata::name));
     PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG
 #undef PARTHENON_INTERNAL_FOR_FLAG
 


### PR DESCRIPTION
## PR Summary

Fixes #84 as identified by @jdolence, and then also fixes a related issues in the comparison operator. I added some new tests, too.

Also fixes up cpplint issues that were pre-existing.

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented. (no new features)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
