### PR TITLE
CI Saves Some Build Logs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,9 @@ parthenon-cuda-short:
       -DKokkos_ENABLE_CUDA_LAMBDA=True
       -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
       ../ && make -j${J} && make -j${J} test
+  artifacts:
+    paths:
+      - /builds/pgrete/parthenon/build-cuda/CMakeFiles/CMakeOutput.log
 
 # run short suite on CPUs
 parthenon-cpu-short:
@@ -54,3 +57,6 @@ parthenon-cpu-short:
     - cmake -DCMAKE_BUILD_TYPE=Debug -DHDF5_ROOT=/usr/local/hdf5/parallel
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
       ../ && make -j${J} && make test
+  artifacts:
+    paths:
+      - /builds/pgrete/parthenon/build-cpu/CMakeFiles/CMakeOutput.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ parthenon-cuda-short:
       ../ && make -j${J} && make -j${J} test
   artifacts:
     paths:
-      - /builds/pgrete/parthenon/build-cuda/CMakeFiles/CMakeOutput.log
+      - build-cuda/CMakeFiles/CMakeOutput.log
 
 # run short suite on CPUs
 parthenon-cpu-short:
@@ -59,4 +59,4 @@ parthenon-cpu-short:
       ../ && make -j${J} && make test
   artifacts:
     paths:
-      - /builds/pgrete/parthenon/build/CMakeFiles/CMakeOutput.log
+      - build/CMakeFiles/CMakeOutput.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,6 +43,8 @@ parthenon-cuda-short:
       -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
       ../ && make -j${J} && make -j${J} test
   artifacts:
+    when: always
+    expire_in: 3 days
     paths:
       - build-cuda/CMakeFiles/CMakeOutput.log
 
@@ -58,5 +60,7 @@ parthenon-cpu-short:
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
       ../ && make -j${J} && make test
   artifacts:
+    when: always
+    expire_in: 3 days
     paths:
       - build/CMakeFiles/CMakeOutput.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,4 +59,4 @@ parthenon-cpu-short:
       ../ && make -j${J} && make test
   artifacts:
     paths:
-      - /builds/pgrete/parthenon/build-cpu/CMakeFiles/CMakeOutput.log
+      - /builds/pgrete/parthenon/build/CMakeFiles/CMakeOutput.log


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When debugging failed CI it can often be helpful to have more than CLI output. In this merge request, I enable the saving of "artifacts," files generated during a test. This both shows how it can be done and generalized and provides two files which might be useful to look at if your code fails to build.
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint (nothing to lint)
- [x] New features are documented. (no new features)
- [x] Adds a test for any bugs fixed. Adds tests for new features. (no new tests)
