### PR TITLE
Add workflows for formatting C++ code

### DIFF
--- a/.github/workflows/apply-formatting.yml
+++ b/.github/workflows/apply-formatting.yml
@@ -6,6 +6,7 @@ jobs:
   apply-formatting:
     name: Format C++ Code
     runs-on: ubuntu-latest
+    if: startsWith(github.event.comment.body, '@hermes format')
     steps:
     - uses: AndrewGaspar/cpp-auto-formatter/command@v0.1
       with:

--- a/.github/workflows/apply-formatting.yml
+++ b/.github/workflows/apply-formatting.yml
@@ -1,0 +1,14 @@
+name: Command Mode Formatting
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  apply-formatting:
+    name: Format C++ Code
+    runs-on: ubuntu-latest
+    steps:
+    - uses: AndrewGaspar/cpp-auto-formatter/command@v0.1
+      with:
+        botName: hermes
+        clangFormatVersion: 8
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apply-formatting.yml
+++ b/.github/workflows/apply-formatting.yml
@@ -6,10 +6,10 @@ jobs:
   apply-formatting:
     name: Format C++ Code
     runs-on: ubuntu-latest
-    if: startsWith(github.event.comment.body, '@hermes format')
+    if: startsWith(github.event.comment.body, '@par-hermes format')
     steps:
     - uses: AndrewGaspar/cpp-auto-formatter/command@v0.1
       with:
-        botName: hermes
+        botName: par-hermes
         clangFormatVersion: 8
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,11 @@
+name: Check Formatting
+on: push
+jobs:
+  check-formatting:
+    name: Check C++ Formatting
+    runs-on: ubuntu-latest
+    steps:
+    - uses: AndrewGaspar/cpp-auto-formatter/check@v0.1
+      with:
+        clangFormatVersion: 8
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Summary
This PR adds two GitHub workflows. `check-formatting.yml` adds a CI item for checking that code is formatted. `apply-formatting.yml` adds a GitHub Action that monitors for comments that start with "@par-hermes format", and applies formatting for that code. You can use "@par-hermes format --amend" to squash the formatting change into the prior commit.

## PR Checklist

- [x] Code passes cpplint (no new C++ code)
- [~] New features are documented. (TODO: Will document once it's working)
- [x] Adds a test for any bugs fixed. Adds tests for new features. (No new features)
