### PR TITLE
Get code building with IBM XL on Power 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,9 @@ if (ENABLE_COMPILER_WARNINGS)
   add_compile_options(-Wall)
 endif()
 
+# We want Kokkos to be built with C++14, since that's what we're using in
+# Parthenon.
+set(Kokkos_CXX_STANDARD 14)
 if(EXISTS ${Kokkos_ROOT}/CMakeLists.txt)
   add_subdirectory(${Kokkos_ROOT} Kokkos)
 elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos/CMakeLists.txt)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,7 +137,11 @@ add_library(parthenon
   parameter_input.cpp
   parthenon_manager.cpp
 )
+
 target_compile_features(parthenon PUBLIC cxx_std_14)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "XL")
+  target_compile_options(parthenon PUBLIC -std=c++1y -qxflag=disable__cplusplusOverride)
+endif()
 
 
 if (ENABLE_MPI)


### PR DESCRIPTION
## PR Summary
This change gets the code building with IBM XL 16.1.1.7. Only required a couple small CMake changes.

The tests currently fail due to an issue with IBM XL when used with Catch2. When the fix to Catch2 is merged, I will update our Catch2 version: https://github.com/catchorg/Catch2/pull/1907

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
