### PR TITLE
Fix space typedefs. Add GetHostMirrorAndCopy

### DIFF
--- a/docs/parthenon_arrays.md
+++ b/docs/parthenon_arrays.md
@@ -80,6 +80,10 @@ my_mirror.DeepCopy(my_array);
 `ParArrayND` provides two convenience functions, `GetHostMirror()` and
 `GetDeviceMirror()` which put a mirror on the host and device
 respectively.
+In addition, `GetHostMirrorAndCopy()` creates a new and deep copies the content, e.g.,
+```C++
+auto my_host_array = my_array.getHostMirrorAndCopy();
+```
 
 ### A note on templates
 
@@ -89,7 +93,7 @@ aliases available are as follows:
 
 ```C++
 template<typename T, typename Layout=LayoutWrapper>
-using device_view_t = Kokkos::View<T******,Layout,DevSpace>;
+using device_view_t = Kokkos::View<T******,Layout,DevMemSpace>;
 
 template<typename T, typename Layout=LayoutWrapper>
 using host_view_t = typename device_view_t<T,Layout>::HostMirror;

--- a/docs/parthenon_arrays.md
+++ b/docs/parthenon_arrays.md
@@ -80,7 +80,8 @@ my_mirror.DeepCopy(my_array);
 `ParArrayND` provides two convenience functions, `GetHostMirror()` and
 `GetDeviceMirror()` which put a mirror on the host and device
 respectively.
-In addition, `GetHostMirrorAndCopy()` creates a new and deep copies the content, e.g.,
+In addition, `GetHostMirrorAndCopy()` creates a new `ParArrayND` on the host
+with identical layout and deep copies the content, e.g.,
 ```C++
 auto my_host_array = my_array.getHostMirrorAndCopy();
 ```

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -27,27 +27,29 @@
 namespace parthenon {
 
 #ifdef KOKKOS_ENABLE_CUDA_UVM
-using DevSpace = Kokkos::CudaUVMSpace;
-using HostSpace = Kokkos::CudaUVMSpace;
+using DevMemSpace = Kokkos::CudaUVMSpace;
+using HostMemSpace = Kokkos::CudaUVMSpace;
+using DevExecSpace = Kokkos::Cuda;
 #else
-using DevSpace = Kokkos::DefaultExecutionSpace;
-using HostSpace = Kokkos::HostSpace;
+using DevMemSpace = Kokkos::DefaultExecutionSpace::memory_space;
+using HostMemSpace = Kokkos::HostSpace;
+using DevExecSpace = Kokkos::DefaultExecutionSpace;
 #endif
 
 using LayoutWrapper = Kokkos::LayoutRight;
 
 template <typename T>
-using ParArray1D = Kokkos::View<T *, LayoutWrapper, DevSpace>;
+using ParArray1D = Kokkos::View<T *, LayoutWrapper, DevMemSpace>;
 template <typename T>
-using ParArray2D = Kokkos::View<T **, LayoutWrapper, DevSpace>;
+using ParArray2D = Kokkos::View<T **, LayoutWrapper, DevMemSpace>;
 template <typename T>
-using ParArray3D = Kokkos::View<T ***, LayoutWrapper, DevSpace>;
+using ParArray3D = Kokkos::View<T ***, LayoutWrapper, DevMemSpace>;
 template <typename T>
-using ParArray4D = Kokkos::View<T ****, LayoutWrapper, DevSpace>;
+using ParArray4D = Kokkos::View<T ****, LayoutWrapper, DevMemSpace>;
 template <typename T>
-using ParArray5D = Kokkos::View<T *****, LayoutWrapper, DevSpace>;
+using ParArray5D = Kokkos::View<T *****, LayoutWrapper, DevMemSpace>;
 template <typename T>
-using ParArray6D = Kokkos::View<T ******, LayoutWrapper, DevSpace>;
+using ParArray6D = Kokkos::View<T ******, LayoutWrapper, DevMemSpace>;
 
 using team_policy = Kokkos::TeamPolicy<>;
 using member_type = Kokkos::TeamPolicy<>::member_type;
@@ -94,7 +96,7 @@ static struct LoopPatternUndefined {
 
 // 1D default loop pattern
 template <typename Function>
-inline void par_for(const std::string &name, DevSpace exec_space, const int &il,
+inline void par_for(const std::string &name, DevExecSpace exec_space, const int &il,
                     const int &iu, const Function &function) {
   // using loop_pattern_mdrange_tag instead of DEFAULT_LOOP_PATTERN for now
   // as the other wrappers are not implemented yet for 1D loops
@@ -103,7 +105,7 @@ inline void par_for(const std::string &name, DevSpace exec_space, const int &il,
 
 // 2D default loop pattern
 template <typename Function>
-inline void par_for(const std::string &name, DevSpace exec_space, const int &jl,
+inline void par_for(const std::string &name, DevExecSpace exec_space, const int &jl,
                     const int &ju, const int &il, const int &iu,
                     const Function &function) {
   // using loop_pattern_mdrange_tag instead of DEFAULT_LOOP_PATTERN for now
@@ -113,7 +115,7 @@ inline void par_for(const std::string &name, DevSpace exec_space, const int &jl,
 
 // 3D default loop pattern
 template <typename Function>
-inline void par_for(const std::string &name, DevSpace exec_space, const int &kl,
+inline void par_for(const std::string &name, DevExecSpace exec_space, const int &kl,
                     const int &ku, const int &jl, const int &ju, const int &il,
                     const int &iu, const Function &function) {
   par_for(DEFAULT_LOOP_PATTERN, name, exec_space, kl, ku, jl, ju, il, iu, function);
@@ -121,7 +123,7 @@ inline void par_for(const std::string &name, DevSpace exec_space, const int &kl,
 
 // 4D default loop pattern
 template <typename Function>
-inline void par_for(const std::string &name, DevSpace exec_space, const int &nl,
+inline void par_for(const std::string &name, DevExecSpace exec_space, const int &nl,
                     const int &nu, const int &kl, const int &ku, const int &jl,
                     const int &ju, const int &il, const int &iu,
                     const Function &function) {
@@ -131,7 +133,7 @@ inline void par_for(const std::string &name, DevSpace exec_space, const int &nl,
 
 // 1D loop using MDRange loops
 template <typename Function>
-inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternMDRange, const std::string &name, DevExecSpace exec_space,
                     const int &il, const int &iu, const Function &function) {
   Kokkos::parallel_for(name,
                        Kokkos::Experimental::require(
@@ -142,7 +144,7 @@ inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_s
 
 // 2D loop using MDRange loops
 template <typename Function>
-inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternMDRange, const std::string &name, DevExecSpace exec_space,
                     const int &jl, const int &ju, const int &il, const int &iu,
                     const Function &function) {
   Kokkos::parallel_for(
@@ -155,9 +157,10 @@ inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_s
 
 // 3D loop using Kokkos 1D Range
 template <typename Function>
-inline void par_for(LoopPatternFlatRange, const std::string &name, DevSpace exec_space,
-                    const int &kl, const int &ku, const int &jl, const int &ju,
-                    const int &il, const int &iu, const Function &function) {
+inline void par_for(LoopPatternFlatRange, const std::string &name,
+                    DevExecSpace exec_space, const int &kl, const int &ku, const int &jl,
+                    const int &ju, const int &il, const int &iu,
+                    const Function &function) {
   const int Nk = ku - kl + 1;
   const int Nj = ju - jl + 1;
   const int Ni = iu - il + 1;
@@ -177,7 +180,7 @@ inline void par_for(LoopPatternFlatRange, const std::string &name, DevSpace exec
 
 // 3D loop using MDRange loops
 template <typename Function>
-inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternMDRange, const std::string &name, DevExecSpace exec_space,
                     const int &kl, const int &ku, const int &jl, const int &ju,
                     const int &il, const int &iu, const Function &function) {
   Kokkos::parallel_for(name,
@@ -190,7 +193,7 @@ inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_s
 
 // 3D loop using TeamPolicy with single inner TeamThreadRange
 template <typename Function>
-inline void par_for(LoopPatternTPTTR, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternTPTTR, const std::string &name, DevExecSpace exec_space,
                     const int &kl, const int &ku, const int &jl, const int &ju,
                     const int &il, const int &iu, const Function &function) {
   const int Nk = ku - kl + 1;
@@ -208,7 +211,7 @@ inline void par_for(LoopPatternTPTTR, const std::string &name, DevSpace exec_spa
 
 // 3D loop using TeamPolicy with single inner ThreadVectorRange
 template <typename Function>
-inline void par_for(LoopPatternTPTVR, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternTPTVR, const std::string &name, DevExecSpace exec_space,
                     const int &kl, const int &ku, const int &jl, const int &ju,
                     const int &il, const int &iu, const Function &function) {
   // TODO(pgrete) if exec space is Cuda,throw error
@@ -227,7 +230,7 @@ inline void par_for(LoopPatternTPTVR, const std::string &name, DevSpace exec_spa
 
 // 3D loop using TeamPolicy with nested TeamThreadRange and ThreadVectorRange
 template <typename Function>
-inline void par_for(LoopPatternTPTTRTVR, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternTPTTRTVR, const std::string &name, DevExecSpace exec_space,
                     const int &kl, const int &ku, const int &jl, const int &ju,
                     const int &il, const int &iu, const Function &function) {
   const int Nk = ku - kl + 1;
@@ -245,7 +248,7 @@ inline void par_for(LoopPatternTPTTRTVR, const std::string &name, DevSpace exec_
 
 // 3D loop using SIMD FOR loops
 template <typename Function>
-inline void par_for(LoopPatternSimdFor, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternSimdFor, const std::string &name, DevExecSpace exec_space,
                     const int &kl, const int &ku, const int &jl, const int &ju,
                     const int &il, const int &iu, const Function &function) {
   Kokkos::Profiling::pushRegion(name);
@@ -259,9 +262,10 @@ inline void par_for(LoopPatternSimdFor, const std::string &name, DevSpace exec_s
 
 // 4D loop using Kokkos 1D Range
 template <typename Function>
-inline void par_for(LoopPatternFlatRange, const std::string &name, DevSpace exec_space,
-                    const int nl, const int nu, const int kl, const int ku, const int jl,
-                    const int ju, const int il, const int iu, const Function &function) {
+inline void par_for(LoopPatternFlatRange, const std::string &name,
+                    DevExecSpace exec_space, const int nl, const int nu, const int kl,
+                    const int ku, const int jl, const int ju, const int il, const int iu,
+                    const Function &function) {
   const int Nn = nu - nl + 1;
   const int Nk = ku - kl + 1;
   const int Nj = ju - jl + 1;
@@ -286,7 +290,7 @@ inline void par_for(LoopPatternFlatRange, const std::string &name, DevSpace exec
 
 // 4D loop using MDRange loops
 template <typename Function>
-inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternMDRange, const std::string &name, DevExecSpace exec_space,
                     const int nl, const int nu, const int kl, const int ku, const int jl,
                     const int ju, const int il, const int iu, const Function &function) {
   Kokkos::parallel_for(
@@ -300,7 +304,7 @@ inline void par_for(LoopPatternMDRange, const std::string &name, DevSpace exec_s
 
 // 4D loop using TeamPolicy loop with inner TeamThreadRange
 template <typename Function>
-inline void par_for(LoopPatternTPTTR, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternTPTTR, const std::string &name, DevExecSpace exec_space,
                     const int nl, const int nu, const int kl, const int ku, const int jl,
                     const int ju, const int il, const int iu, const Function &function) {
   const int Nn = nu - nl + 1;
@@ -323,7 +327,7 @@ inline void par_for(LoopPatternTPTTR, const std::string &name, DevSpace exec_spa
 
 // 4D loop using TeamPolicy loop with inner ThreadVectorRange
 template <typename Function>
-inline void par_for(LoopPatternTPTVR, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternTPTVR, const std::string &name, DevExecSpace exec_space,
                     const int nl, const int nu, const int kl, const int ku, const int jl,
                     const int ju, const int il, const int iu, const Function &function) {
   // TODO(pgrete) if exec space is Cuda,throw error
@@ -347,7 +351,7 @@ inline void par_for(LoopPatternTPTVR, const std::string &name, DevSpace exec_spa
 
 // 4D loop using TeamPolicy with nested TeamThreadRange and ThreadVectorRange
 template <typename Function>
-inline void par_for(LoopPatternTPTTRTVR, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternTPTTRTVR, const std::string &name, DevExecSpace exec_space,
                     const int nl, const int nu, const int kl, const int ku, const int jl,
                     const int ju, const int il, const int iu, const Function &function) {
   const int Nn = nu - nl + 1;
@@ -368,7 +372,7 @@ inline void par_for(LoopPatternTPTTRTVR, const std::string &name, DevSpace exec_
 
 // 4D loop using SIMD FOR loops
 template <typename Function>
-inline void par_for(LoopPatternSimdFor, const std::string &name, DevSpace exec_space,
+inline void par_for(LoopPatternSimdFor, const std::string &name, DevExecSpace exec_space,
                     const int nl, const int nu, const int kl, const int ku, const int jl,
                     const int ju, const int il, const int iu, const Function &function) {
   Kokkos::Profiling::pushRegion(name);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -95,7 +95,7 @@ class MeshBlock {
   ~MeshBlock();
 
   // Kokkos execution space for this MeshBlock
-  DevSpace exec_space;
+  DevExecSpace exec_space;
 
   // data
   Mesh *pmy_mesh; // ptr to Mesh containing this MeshBlock

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -52,9 +52,9 @@ MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_
                      BoundaryFlag *input_bcs, Mesh *pm, ParameterInput *pin,
                      Properties_t &properties, Packages_t &packages, int igflag,
                      bool ref_flag)
-    : exec_space(DevSpace()), pmy_mesh(pm), loc(iloc), block_size(input_block), gid(igid),
-      lid(ilid), gflag(igflag), properties(properties), packages(packages), prev(nullptr),
-      next(nullptr), new_block_dt_{}, new_block_dt_hyperbolic_{},
+    : exec_space(DevExecSpace()), pmy_mesh(pm), loc(iloc), block_size(input_block),
+      gid(igid), lid(ilid), gflag(igflag), properties(properties), packages(packages),
+      prev(nullptr), next(nullptr), new_block_dt_{}, new_block_dt_hyperbolic_{},
       new_block_dt_parabolic_{}, new_block_dt_user_{}, cost_(1.0) {
   // initialize grid indices
   is = NGHOST;
@@ -168,7 +168,7 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
       gflag(igflag), nuser_out_var(), properties(properties), packages(packages),
       prev(nullptr), next(nullptr), new_block_dt_{}, new_block_dt_hyperbolic_{},
       new_block_dt_parabolic_{}, new_block_dt_user_{}, nreal_user_meshblock_data_(),
-      nint_user_meshblock_data_(), cost_(icost), exec_space(DevSpace()) {
+      nint_user_meshblock_data_(), cost_(icost), exec_space(DevExecSpace()) {
   // initialize grid indices
 
   // std::cerr << "WHY AM I HERE???" << std::endl;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -253,7 +253,6 @@ void PHDF5Output::genXDMF(std::string hdfFile, Mesh *pm) {
 //  \brief Cycles over all MeshBlocks and writes OutputData in the Parthenon HDF5 format,
 //         one file per output using parallel IO.
 void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
-
   // writes all graphics variables to hdf file
   // HDF5 structures
   // Also writes companion xdmf file

--- a/src/parthenon_arrays.hpp
+++ b/src/parthenon_arrays.hpp
@@ -143,11 +143,12 @@ class ParArrayNDGeneric {
     Kokkos::deep_copy(d6d_, src.Get());
   }
 
-  auto GetHostMirrorAndCopy() {
-    auto host_mirror = GetHostMirror();
-    Kokkos::deep_copy(host_mirror.Get(), d6d_);
-    return host_mirror;
+  template <typename MemSpace>
+  auto GetMirrorAndCopy(MemSpace const &memspace) {
+    auto mirror = Kokkos::create_mirror_view_and_copy(memspace, d6d_);
+    return ParArrayNDGeneric<decltype(mirror)>(mirror);
   }
+  auto GetHostMirrorAndCopy() { return GetMirrorAndCopy(Kokkos::HostSpace()); }
 
   // JMM: DO NOT put noexcept here. It somehow interferes with inlining
   // and the code slows down by a factor of 5.

--- a/src/parthenon_arrays.hpp
+++ b/src/parthenon_arrays.hpp
@@ -130,7 +130,6 @@ class ParArrayNDGeneric {
     return GetDim(1) * GetDim(2) * GetDim(3) * GetDim(4) * GetDim(5) * GetDim(6);
   }
 
-  // TODO(JMM): expose wrapper for create_mirror_view_and_copy?
   template <typename MemSpace>
   auto GetMirror(MemSpace const &memspace) {
     auto mirror = Kokkos::create_mirror_view(memspace, d6d_);
@@ -142,6 +141,12 @@ class ParArrayNDGeneric {
   template <typename Other>
   void DeepCopy(const Other &src) {
     Kokkos::deep_copy(d6d_, src.Get());
+  }
+
+  auto GetHostMirrorAndCopy() {
+    auto host_mirror = GetHostMirror();
+    Kokkos::deep_copy(host_mirror.Get(), d6d_);
+    return host_mirror;
   }
 
   // JMM: DO NOT put noexcept here. It somehow interferes with inlining
@@ -286,7 +291,7 @@ class ParArrayNDGeneric {
 };
 
 template <typename T, typename Layout = LayoutWrapper>
-using device_view_t = Kokkos::View<T ******, Layout, DevSpace>;
+using device_view_t = Kokkos::View<T ******, Layout, DevMemSpace>;
 
 template <typename T, typename Layout = LayoutWrapper>
 using host_view_t = typename device_view_t<T, Layout>::HostMirror;

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -25,7 +25,7 @@
 
 #include "kokkos_abstraction.hpp"
 
-using parthenon::DevSpace;
+using parthenon::DevExecSpace;
 using parthenon::ParArray1D;
 using parthenon::ParArray2D;
 using parthenon::ParArray3D;
@@ -33,7 +33,7 @@ using parthenon::ParArray4D;
 using Real = double;
 
 template <class T>
-bool test_wrapper_1d(T loop_pattern, DevSpace exec_space) {
+bool test_wrapper_1d(T loop_pattern, DevExecSpace exec_space) {
   // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
   std::random_device rd;  // Will be used to obtain a seed for the random number engine
   std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
@@ -71,7 +71,7 @@ bool test_wrapper_1d(T loop_pattern, DevSpace exec_space) {
 }
 
 template <class T>
-bool test_wrapper_2d(T loop_pattern, DevSpace exec_space) {
+bool test_wrapper_2d(T loop_pattern, DevExecSpace exec_space) {
   // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
   std::random_device rd;  // Will be used to obtain a seed for the random number engine
   std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
@@ -113,7 +113,7 @@ bool test_wrapper_2d(T loop_pattern, DevSpace exec_space) {
 }
 
 template <class T>
-bool test_wrapper_3d(T loop_pattern, DevSpace exec_space) {
+bool test_wrapper_3d(T loop_pattern, DevExecSpace exec_space) {
   // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
   std::random_device rd;  // Will be used to obtain a seed for the random number engine
   std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
@@ -158,7 +158,7 @@ bool test_wrapper_3d(T loop_pattern, DevSpace exec_space) {
 }
 
 template <class T>
-bool test_wrapper_4d(T loop_pattern, DevSpace exec_space) {
+bool test_wrapper_4d(T loop_pattern, DevExecSpace exec_space) {
   // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
   std::random_device rd;  // Will be used to obtain a seed for the random number engine
   std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
@@ -205,7 +205,7 @@ bool test_wrapper_4d(T loop_pattern, DevSpace exec_space) {
 }
 
 TEST_CASE("par_for loops", "[wrapper]") {
-  auto default_exec_space = DevSpace();
+  auto default_exec_space = DevExecSpace();
 
   SECTION("1D loops") {
     REQUIRE(test_wrapper_1d(parthenon::loop_pattern_mdrange_tag, default_exec_space) ==
@@ -375,7 +375,7 @@ struct LargeNShortTBufferPack {
     }
   }
 
-  void run(DevSpace exec_space) {
+  void run(DevExecSpace exec_space) {
     const int nbuffers = 6; // number of buffers, here up, down, left, right, back, front
     auto M = arr_in.extent(0);
     auto slab_size = buf_im.extent(0) / M;
@@ -445,7 +445,7 @@ struct SmallNLongTBufferPack {
     }
   }
 
-  void run(DevSpace exec_space) {
+  void run(DevExecSpace exec_space) {
     auto M = arr_in.extent(0);
     const int nbuffers = 6; // number of buffers, here up, down, left, right, back, front
     parthenon::par_for(parthenon::loop_pattern_mdrange_tag, "SmallNLongTBufferPack",
@@ -462,7 +462,7 @@ struct SmallNLongTBufferPack {
 
 template <class BufferPack>
 void test_wrapper_buffer_pack_overlapping_space_instances(const std::string test_name) {
-  auto default_exec_space = DevSpace();
+  auto default_exec_space = DevExecSpace();
 
   const int N = 32;      // ~meshblock size
   const int M = 5;       // ~nhydro
@@ -471,7 +471,7 @@ void test_wrapper_buffer_pack_overlapping_space_instances(const std::string test
   const int buf_size = M * nghost * (N - 2 * nghost) * (N - 2 * nghost);
 
   std::vector<BufferPack> functs;
-  std::vector<DevSpace> exec_spaces;
+  std::vector<DevExecSpace> exec_spaces;
 
   for (auto n = 0; n < nspaces; n++) {
     functs.push_back(BufferPack(
@@ -479,7 +479,7 @@ void test_wrapper_buffer_pack_overlapping_space_instances(const std::string test
         ParArray1D<Real>("buf_ip", buf_size), ParArray1D<Real>("buf_im", buf_size),
         ParArray1D<Real>("buf_jp", buf_size), ParArray1D<Real>("buf_jm", buf_size),
         ParArray1D<Real>("buf_kp", buf_size), ParArray1D<Real>("buf_kp", buf_size)));
-    exec_spaces.push_back(parthenon::SpaceInstance<DevSpace>::create());
+    exec_spaces.push_back(parthenon::SpaceInstance<DevExecSpace>::create());
   }
 
   // warmup
@@ -517,7 +517,7 @@ void test_wrapper_buffer_pack_overlapping_space_instances(const std::string test
 
   // make sure this test is reasonable IIF streams actually overlap, which is
   // not the case for the OpenMP backend at this point
-  if (parthenon::SpaceInstance<DevSpace>::overlap()) {
+  if (parthenon::SpaceInstance<DevExecSpace>::overlap()) {
     BufferPack::test_time(time_default, time_spaces, nspaces);
   }
 }

--- a/tst/unit/test_container_iterator.cpp
+++ b/tst/unit/test_container_iterator.cpp
@@ -34,7 +34,7 @@
 using parthenon::CellVariableVector;
 using parthenon::Container;
 using parthenon::ContainerIterator;
-using parthenon::DevSpace;
+using parthenon::DevExecSpace;
 using parthenon::loop_pattern_mdrange_tag;
 using parthenon::Metadata;
 using parthenon::par_for;
@@ -62,8 +62,8 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       for (int n = 0; n < cv.size(); n++) {
         ParArrayND<Real> v = cv[n]->data;
         par_for(
-            "Initialize variables", DevSpace(), 0, v.GetDim(4) - 1, 0, v.GetDim(3) - 1, 0,
-            v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
+            "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0,
+            v.GetDim(3) - 1, 0, v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
             KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
               v(l, k, j, i) = 0.0;
             });
@@ -109,7 +109,7 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       for (int n = 0; n < civ.size(); n++) {
         ParArrayND<Real> v = civ[n]->data;
         par_for(
-            "Set independent variables", DevSpace(), 0, v.GetDim(4) - 1, 0,
+            "Set independent variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0,
             v.GetDim(3) - 1, 0, v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
             KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
               v(l, k, j, i) = 1.0;

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -27,7 +27,8 @@
 #include "kokkos_abstraction.hpp"
 #include "parthenon_arrays.hpp"
 
-using parthenon::DevSpace;
+using parthenon::DevExecSpace;
+using parthenon::DevMemSpace;
 using parthenon::ParArray3D;
 using parthenon::ParArrayND;
 using Real = double;
@@ -43,7 +44,7 @@ constexpr int NARRAYS = 64;
 #ifdef KOKKOS_ENABLE_CUDA
 using UVMSpace = Kokkos::CudaUVMSpace;
 #else // all on host
-using UVMSpace = DevSpace;
+using UVMSpace = DevMemSpace;
 #endif
 
 KOKKOS_INLINE_FUNCTION Real coord(const int i, const int n) {
@@ -76,7 +77,7 @@ KOKKOS_FORCEINLINE_FUNCTION void stencil(T &l, T &r, const int k, const int j,
 
 template <class T>
 void profile_wrapper_3d(T loop_pattern) {
-  auto exec_space = DevSpace();
+  auto exec_space = DevExecSpace();
   Kokkos::Timer timer;
 
   ParArray3D<Real> raw0("raw", N, N, N);
@@ -154,6 +155,32 @@ TEST_CASE("ParArrayND", "[ParArrayND][Kokkos]") {
     ParArrayND<Real> a(PARARRAY_TEMP, 5, 4, 3, 2);
     THEN("The label is the correct default") {
       REQUIRE(a.label().find("ParArrayND") != std::string::npos);
+    }
+  }
+
+  GIVEN("A ParArrayND with some numbers and its Kokkos host mirror copy") {
+    ParArrayND<Real> a("GetMirrorAndCopy", 5, 4, 3);
+
+    Kokkos::parallel_for(
+        policy3d({0, 0, 0}, {5, 4, 3}),
+        KOKKOS_LAMBDA(const int k, const int j, const int i) {
+          a(k, j, i) = static_cast<Real>(k * j * i);
+        });
+
+    auto a_host_raw = Kokkos::create_mirror_view(a.Get<3>());
+    Kokkos::deep_copy(a_host_raw, a.Get<3>());
+
+    THEN("The GetHostMirrorAndCopy is identical") {
+      auto a_host_wrap = a.GetHostMirrorAndCopy();
+      bool same = true;
+      for (int k = 0; k < 5; k++)
+        for (int j = 0; j < 4; j++)
+          for (int i = 0; i < 3; i++) {
+            if (a_host_raw(k, j, i) != a_host_wrap(k, j, i)) {
+              same = false;
+            }
+          }
+      REQUIRE(same);
     }
   }
 
@@ -336,7 +363,7 @@ TEST_CASE("Time simple stencil operations", "[ParArrayND][performance]") {
 // clang-format on
 
 TEST_CASE("Check registry pressure", "[ParArrayND][performance]") {
-  auto exec_space = DevSpace();
+  auto exec_space = DevExecSpace();
   Kokkos::Timer timer;
 
   // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution
@@ -433,7 +460,7 @@ many_array_kernel(const Array &arr0, const Array &arr1, const Array &arr2,
 }
 
 TEST_CASE("Check many arrays", "[ParArrayND][performance]") {
-  auto exec_space = DevSpace();
+  auto exec_space = DevExecSpace();
   Kokkos::Timer timer;
 
   // https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution

--- a/tst/unit/test_unit_face_variables.cpp
+++ b/tst/unit/test_unit_face_variables.cpp
@@ -27,7 +27,7 @@
 #include "interface/variable.hpp"
 #include "kokkos_abstraction.hpp"
 
-using parthenon::DevSpace;
+using parthenon::DevExecSpace;
 using parthenon::FaceVariable;
 using parthenon::loop_pattern_mdrange_tag;
 using parthenon::Metadata;
@@ -64,7 +64,7 @@ TEST_CASE("Can create a vector-valued face-variable",
         }
         AND_THEN("The metadata is correct") { REQUIRE(f.metadata() == m); }
         AND_THEN("We can set array elements") {
-          auto space = DevSpace();
+          auto space = DevExecSpace();
           auto x1f = f.Get(1);
           auto x2f = f.Get(2);
           auto x3f = f.Get(3);


### PR DESCRIPTION

## PR Summary

Addressed two items
- Cleanup of the `DevSpace` and `HostSpace` types that incorrectly were used for both execution and memory spaces (lead to problems with the wrappers when enabling UVM). Now there are `DevExecSpace`, `DevMemSpace`, and `HostMemSpace` to distinguish between those.
- Add a `GetHostMirrorAndCopy` function to the `ParArrays`s which does what it name stands for. This will be useful, e.g., during the simulation setup in the process of Kokkosizing the remainder of the codebase.

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
