### PR TITLE
Sriram/named iterator initialization

### DIFF
--- a/src/interface/container_iterator.hpp
+++ b/src/interface/container_iterator.hpp
@@ -20,6 +20,7 @@
 
 #include <array>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "interface/container.hpp"
@@ -38,33 +39,58 @@ class ContainerIterator {
 
   /// initializes the iterator with a container and a flag to match
   /// @param c the container on which you want the iterator
-  /// @param flagVector: a vector of Metadata::flags that you want to match
+  /// @param flags: a vector of Metadata::flags that you want to match
   ContainerIterator<T>(const Container<T> &c,
-                       const std::vector<MetadataFlag> &flagVector) {
+                       const std::vector<MetadataFlag> &flags) {
     // c.print();
-    auto allVars = c.GetCellVariableVector();
+    allVars_ = c.GetCellVariableVector();
     for (auto &svar : c.GetSparseVector()) {
       CellVariableVector<T> &svec = svar->GetVector();
-      allVars.insert(allVars.end(), svec.begin(), svec.end());
+      allVars_.insert(allVars_.end(), svec.begin(), svec.end());
     }
     // faces not active yet    allFaceVars_ = c.faceVars();
     // edges not active yet    allEdgeVars_ = c.edgeVars();
-    setMask(allVars, flagVector); // fill subset based on mask vector
+    resetVars(flags); // fill subset based on mask vector
   }
 
-  //~ContainerIterator<T>() {
-  //  emptyVars_();
-  //}
+  /// initializes the iterator with a container and a flag to match
+  /// @param c the container on which you want the iterator
+  /// @param names: a vector of std::string with names you want to match
+  ContainerIterator<T>(const Container<T> &c,
+                       const std::vector<std::string> &names) {
+    // c.print();
+    allVars_ = c.GetCellVariableVector();
+    for (auto &svar : c.GetSparseVector()) {
+      CellVariableVector<T> &svec = svar->GetVector();
+      allVars_.insert(allVars_.end(), svec.begin(), svec.end());
+    }
+    // faces not active yet    allFaceVars_ = c.faceVars();
+    // edges not active yet    allEdgeVars_ = c.edgeVars();
+    resetVars(names); // fill subset based on mask vector
+  }
+
   /// Changes the mask for the iterator and resets the iterator
-  /// @param flagArray: a vector of MetadataFlag that you want to match
-  void setMask(const CellVariableVector<T> &allVars,
-               const std::vector<MetadataFlag> &flagVector) {
+  /// @param names: a vector of MetadataFlag that you want to match
+  void resetVars( const std::vector<std::string> &names ) {
+    // 1: clear out variables stored so far
+    emptyVars_();
+
+    // 2: fill in the subset of variables that match at least one entry in names
+    for ( auto pv : allVars_ ) {
+      if (std::find(names.begin(), names.end(), pv->label()) != names.end())
+        vars.push_back(pv);
+    }
+  }
+
+  /// Changes the mask for the iterator and resets the iterator
+  /// @param flags: a vector of MetadataFlag that you want to match
+  void resetVars( const std::vector<MetadataFlag> &flags ) {
     // 1: clear out variables stored so far
     emptyVars_();
 
     // 2: fill in the subset of variables that match mask
-    for (auto pv : allVars) {
-      if (pv->metadata().AnyFlagsSet(flagVector)) {
+    for ( auto pv : allVars_ ) {
+      if (pv->metadata().AnyFlagsSet(flags)) {
         vars.push_back(pv);
       }
     }
@@ -72,41 +98,13 @@ class ContainerIterator {
 
  private:
   uint64_t mask_;
-  FaceVector<T> allFaceVars_ = {};
+  CellVariableVector<T> allVars_;
+  // FaceVector<T> allFaceVars_ = {};
   // EdgeVector<T> allEdgeVars_ = {};
-  // CellVariableVector<T> allVars_ = {};
   void emptyVars_() {
     vars.clear();
     //  varsFace.clear();
     //  varsEdge.clear();
-  }
-  static bool couldBeEdge(const std::vector<MetadataFlag> &flagVector) {
-    // returns true if face is set or if no topology set
-    for (auto &f : flagVector) {
-      if (f == Metadata::Edge)
-        return true;
-      else if (f == Metadata::Cell)
-        return false;
-      else if (f == Metadata::Face)
-        return false;
-      else if (f == Metadata::Node)
-        return false;
-    }
-    return true;
-  }
-  static bool couldBeFace(const std::vector<MetadataFlag> &flagVector) {
-    // returns true if face is set or if no topology set
-    for (auto &f : flagVector) {
-      if (f == Metadata::Face)
-        return true;
-      else if (f == Metadata::Cell)
-        return false;
-      else if (f == Metadata::Edge)
-        return false;
-      else if (f == Metadata::Node)
-        return false;
-    }
-    return true;
   }
 };
 

--- a/src/interface/container_iterator.hpp
+++ b/src/interface/container_iterator.hpp
@@ -40,9 +40,7 @@ class ContainerIterator {
   /// initializes the iterator with a container and a flag to match
   /// @param c the container on which you want the iterator
   /// @param flags: a vector of Metadata::flags that you want to match
-  ContainerIterator<T>(const Container<T> &c,
-                       const std::vector<MetadataFlag> &flags) {
-    // c.print();
+  ContainerIterator<T>(const Container<T> &c, const std::vector<MetadataFlag> &flags) {
     allVars_ = c.GetCellVariableVector();
     for (auto &svar : c.GetSparseVector()) {
       CellVariableVector<T> &svec = svar->GetVector();
@@ -56,9 +54,7 @@ class ContainerIterator {
   /// initializes the iterator with a container and a flag to match
   /// @param c the container on which you want the iterator
   /// @param names: a vector of std::string with names you want to match
-  ContainerIterator<T>(const Container<T> &c,
-                       const std::vector<std::string> &names) {
-    // c.print();
+  ContainerIterator<T>(const Container<T> &c, const std::vector<std::string> &names) {
     allVars_ = c.GetCellVariableVector();
     for (auto &svar : c.GetSparseVector()) {
       CellVariableVector<T> &svec = svar->GetVector();
@@ -71,12 +67,12 @@ class ContainerIterator {
 
   /// Changes the mask for the iterator and resets the iterator
   /// @param names: a vector of MetadataFlag that you want to match
-  void resetVars( const std::vector<std::string> &names ) {
+  void resetVars(const std::vector<std::string> &names) {
     // 1: clear out variables stored so far
     emptyVars_();
 
     // 2: fill in the subset of variables that match at least one entry in names
-    for ( auto pv : allVars_ ) {
+    for (auto pv : allVars_) {
       if (std::find(names.begin(), names.end(), pv->label()) != names.end())
         vars.push_back(pv);
     }
@@ -84,12 +80,12 @@ class ContainerIterator {
 
   /// Changes the mask for the iterator and resets the iterator
   /// @param flags: a vector of MetadataFlag that you want to match
-  void resetVars( const std::vector<MetadataFlag> &flags ) {
+  void resetVars(const std::vector<MetadataFlag> &flags) {
     // 1: clear out variables stored so far
     emptyVars_();
 
     // 2: fill in the subset of variables that match mask
-    for ( auto pv : allVars_ ) {
+    for (auto pv : allVars_) {
       if (pv->metadata().AnyFlagsSet(flags)) {
         vars.push_back(pv);
       }

--- a/tst/unit/test_container_iterator.cpp
+++ b/tst/unit/test_container_iterator.cpp
@@ -59,8 +59,8 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
     WHEN("We initialize all variables to zero") {
       // set them all to zero
       const CellVariableVector<Real> &cv = rc.GetCellVariableVector();
-      for (auto &vec : cv) {
-        ParArrayND<Real> v = vec->data;
+      for (int n = 0; n < cv.size(); n++) {
+        ParArrayND<Real> v = cv[n]->data;
         par_for(
             "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0,
             v.GetDim(3) - 1, 0, v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
@@ -71,9 +71,9 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
 
       THEN("they should sum to zero") {
         Real total = 0.0;
-        for (auto &vec : cv) {
+        for (int n = 0; n < cv.size(); n++) {
+          ParArrayND<Real> v = cv[n]->data;
           using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
-          ParArrayND<Real> v = vec->data;
           Real sum = 0.0;
           Kokkos::parallel_reduce(
               policy4D({0, 0, 0, 0},
@@ -88,9 +88,9 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
 
       AND_THEN("we touch the right number of elements") {
         int nElements = 0;
-        for (auto &vec : cv) {
+        for (int n = 0; n < cv.size(); n++) {
+          ParArrayND<Real> v = cv[n]->data;
           using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
-          ParArrayND<Real> v = vec->data;
           int sum;
           Kokkos::parallel_reduce(
               policy4D({0, 0, 0, 0},

--- a/tst/unit/test_container_iterator.cpp
+++ b/tst/unit/test_container_iterator.cpp
@@ -41,36 +41,36 @@ using parthenon::par_for;
 using parthenon::ParArrayND;
 using parthenon::Real;
 
-
-static void setVector( const ParArrayND<Real> &v, const Real &value) {
+static void setVector(const ParArrayND<Real> &v, const Real &value) {
   par_for(
-	  "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0, v.GetDim(3) - 1, 0,
-	  v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
-	  KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
-	    v(l, k, j, i) = value;
-	  });
+      "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0, v.GetDim(3) - 1, 0,
+      v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
+      KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
+        v(l, k, j, i) = value;
+      });
 }
 
-static Real sumVector( const ParArrayND<Real> &v ) {
+static Real sumVector(const ParArrayND<Real> &v) {
   using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
   Real sum = 0.0;
   Kokkos::parallel_reduce(
-			  policy4D({0, 0, 0, 0},
-				   {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
-			  KOKKOS_LAMBDA(const int l, const int k, const int j, const int i,
-					Real &vsum) { vsum += v(l, k, j, i); },
-			  sum);
+      policy4D({0, 0, 0, 0}, {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
+      KOKKOS_LAMBDA(const int l, const int k, const int j, const int i, Real &vsum) {
+        vsum += v(l, k, j, i);
+      },
+      sum);
   return sum;
 }
 
-static int numElements( const ParArrayND<Real> &v ) {
+static int numElements(const ParArrayND<Real> &v) {
   using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
   int sum;
-  Kokkos::parallel_reduce( policy4D({0, 0, 0, 0},
-				    {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
-			   KOKKOS_LAMBDA(const int l, const int k, const int j, const int i,
-					 int &cnt) { cnt++; },
-			   sum);
+  Kokkos::parallel_reduce(
+      policy4D({0, 0, 0, 0}, {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
+      KOKKOS_LAMBDA(const int l, const int k, const int j, const int i, int &cnt) {
+        cnt++;
+      },
+      sum);
   return sum;
 }
 
@@ -92,17 +92,23 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
     WHEN("We initialize all variables to zero") {
       // set them all to zero
       const CellVariableVector<Real> &cv = rc.GetCellVariableVector();
-      for (auto &vec : cv ) { setVector(vec->data, 0.0); }
+      for (auto &vec : cv) {
+        setVector(vec->data, 0.0);
+      }
 
       THEN("they should sum to zero") {
         Real total = 0.0;
-        for (auto &vec : cv ) { total += sumVector(vec->data); }
+        for (auto &vec : cv) {
+          total += sumVector(vec->data);
+        }
         REQUIRE(total == 0.0);
       }
 
       AND_THEN("we touch the right number of elements") {
         int nElements = 0;
-        for (auto &vec : cv ) { nElements += numElements(vec->data); }
+        for (auto &vec : cv) {
+          nElements += numElements(vec->data);
+        }
         REQUIRE(nElements == 40960);
       }
     }
@@ -113,14 +119,14 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       CellVariableVector<Real> &civ = ci.vars;
       for (int n = 0; n < civ.size(); n++) {
         ParArrayND<Real> &v = civ[n]->data;
-	setVector(v, 1.0);
+        setVector(v, 1.0);
       }
 
       THEN("they should sum appropriately") {
         Real total = 0.0;
         for (int n = 0; n < civ.size(); n++) {
           ParArrayND<Real> &v = civ[n]->data;
-	  total += sumVector(v);
+          total += sumVector(v);
         }
         REQUIRE(std::abs(total - 20480.0) < 1.e-14);
       }

--- a/tst/unit/test_container_iterator.cpp
+++ b/tst/unit/test_container_iterator.cpp
@@ -41,39 +41,6 @@ using parthenon::par_for;
 using parthenon::ParArrayND;
 using parthenon::Real;
 
-static void setVector(const ParArrayND<Real> &v, const Real &value) {
-  par_for(
-      "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0, v.GetDim(3) - 1, 0,
-      v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
-      KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
-        v(l, k, j, i) = value;
-      });
-}
-
-static Real sumVector(const ParArrayND<Real> &v) {
-  using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
-  Real sum = 0.0;
-  Kokkos::parallel_reduce(
-      policy4D({0, 0, 0, 0}, {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
-      KOKKOS_LAMBDA(const int l, const int k, const int j, const int i, Real &vsum) {
-        vsum += v(l, k, j, i);
-      },
-      sum);
-  return sum;
-}
-
-static int numElements(const ParArrayND<Real> &v) {
-  using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
-  int sum;
-  Kokkos::parallel_reduce(
-      policy4D({0, 0, 0, 0}, {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
-      KOKKOS_LAMBDA(const int l, const int k, const int j, const int i, int &cnt) {
-        cnt++;
-      },
-      sum);
-  return sum;
-}
-
 TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIterator]") {
   GIVEN("A Container with a set of variables") {
     Container<Real> rc;
@@ -93,13 +60,28 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       // set them all to zero
       const CellVariableVector<Real> &cv = rc.GetCellVariableVector();
       for (auto &vec : cv) {
-        setVector(vec->data, 0.0);
+        ParArrayND<Real> v = vec->data;
+        par_for(
+            "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0,
+            v.GetDim(3) - 1, 0, v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
+            KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
+              v(l, k, j, i) = 0.0;
+            });
       }
 
       THEN("they should sum to zero") {
         Real total = 0.0;
         for (auto &vec : cv) {
-          total += sumVector(vec->data);
+          using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
+          ParArrayND<Real> v = vec->data;
+          Real sum = 0.0;
+          Kokkos::parallel_reduce(
+              policy4D({0, 0, 0, 0},
+                       {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
+              KOKKOS_LAMBDA(const int l, const int k, const int j, const int i,
+                            Real &vsum) { vsum += v(l, k, j, i); },
+              sum);
+          total += sum;
         }
         REQUIRE(total == 0.0);
       }
@@ -107,7 +89,16 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       AND_THEN("we touch the right number of elements") {
         int nElements = 0;
         for (auto &vec : cv) {
-          nElements += numElements(vec->data);
+          using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
+          ParArrayND<Real> v = vec->data;
+          int sum;
+          Kokkos::parallel_reduce(
+              policy4D({0, 0, 0, 0},
+                       {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
+              KOKKOS_LAMBDA(const int l, const int k, const int j, const int i,
+                            int &cnt) { cnt++; },
+              sum);
+          nElements += sum;
         }
         REQUIRE(nElements == 40960);
       }
@@ -119,14 +110,27 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       CellVariableVector<Real> &civ = ci.vars;
       for (int n = 0; n < civ.size(); n++) {
         ParArrayND<Real> &v = civ[n]->data;
-        setVector(v, 1.0);
+        par_for(
+            "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0,
+            v.GetDim(3) - 1, 0, v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
+            KOKKOS_LAMBDA(const int l, const int k, const int j, const int i) {
+              v(l, k, j, i) = 1.0;
+            });
       }
 
       THEN("they should sum appropriately") {
         Real total = 0.0;
         for (int n = 0; n < civ.size(); n++) {
+          using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
           ParArrayND<Real> &v = civ[n]->data;
-          total += sumVector(v);
+          Real sum = 0.0;
+          Kokkos::parallel_reduce(
+              policy4D({0, 0, 0, 0},
+                       {v.GetDim(4), v.GetDim(3), v.GetDim(2), v.GetDim(1)}),
+              KOKKOS_LAMBDA(const int l, const int k, const int j, const int i,
+                            Real &vsum) { vsum += v(l, k, j, i); },
+              sum);
+          total += sum;
         }
         REQUIRE(std::abs(total - 20480.0) < 1.e-14);
       }

--- a/tst/unit/test_container_iterator.cpp
+++ b/tst/unit/test_container_iterator.cpp
@@ -109,7 +109,7 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
       ContainerIterator<Real> ci(rc, {Metadata::Independent});
       CellVariableVector<Real> &civ = ci.vars;
       for (int n = 0; n < civ.size(); n++) {
-        ParArrayND<Real> &v = civ[n]->data;
+        ParArrayND<Real> v = civ[n]->data;
         par_for(
             "Initialize variables", DevExecSpace(), 0, v.GetDim(4) - 1, 0,
             v.GetDim(3) - 1, 0, v.GetDim(2) - 1, 0, v.GetDim(1) - 1,
@@ -122,7 +122,7 @@ TEST_CASE("Can pull variables from containers based on Metadata", "[ContainerIte
         Real total = 0.0;
         for (int n = 0; n < civ.size(); n++) {
           using policy4D = Kokkos::MDRangePolicy<Kokkos::Rank<4>>;
-          ParArrayND<Real> &v = civ[n]->data;
+          ParArrayND<Real> v = civ[n]->data;
           Real sum = 0.0;
           Kokkos::parallel_reduce(
               policy4D({0, 0, 0, 0},


### PR DESCRIPTION
Allows creation of a ContainerIterator using a vector of variable names instead of a set of metadata flags.  The code just uses std::find to find the variables by name and adds them to the vars member.
