### PR TITLE
fix CMake GLOB expressions to not match files starting with .

### DIFF
--- a/cmake/CheckCopyright.cmake
+++ b/cmake/CheckCopyright.cmake
@@ -14,10 +14,10 @@
 # TODO: Probably shouldn't be done at configure time - instead we should have a separate
 # build task that does this.
 
-file(GLOB_RECURSE COPYRIGHTABLE_SOURCES src/*.cpp example/*.cpp)
-file(GLOB_RECURSE COPYRIGHTABLE_HEADERS src/*.hpp example/*.hpp)
-file(GLOB_RECURSE COPYRIGHTABLE_SCRIPTS scripts/python/*.py)
-file(GLOB_RECURSE COPYRIGHTABLE_CMAKE cmake/* src/CMakeLists.txt example/CMakeLists.txt)
+file(GLOB_RECURSE COPYRIGHTABLE_SOURCES src/[^\.]*.cpp example/[^\.]*.cpp)
+file(GLOB_RECURSE COPYRIGHTABLE_HEADERS src/[^\.]*.hpp example/[^\.]*.hpp)
+file(GLOB_RECURSE COPYRIGHTABLE_SCRIPTS scripts/python/[^\.]*.py)
+file(GLOB_RECURSE COPYRIGHTABLE_CMAKE cmake/[^\.]* src/CMakeLists.txt example/CMakeLists.txt)
 
 set(COPYRIGHTABLE
     ${COPYRIGHTABLE_SOURCES}

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -49,10 +49,10 @@ endif()
 
 # Specifically trying to exclude external here - I'm not sure if there's a better way
 set(
-    GLOBS 
-    ${PROJECT_SOURCE_DIR}/src/*.cpp     ${PROJECT_SOURCE_DIR}/src/*.hpp
-    ${PROJECT_SOURCE_DIR}/tst/*.cpp     ${PROJECT_SOURCE_DIR}/tst/*.hpp
-    ${PROJECT_SOURCE_DIR}/example/*.cpp ${PROJECT_SOURCE_DIR}/example/*.hpp
+    GLOBS
+    ${PROJECT_SOURCE_DIR}/src/[^\.]*.cpp     ${PROJECT_SOURCE_DIR}/src/[^\.]*.hpp
+    ${PROJECT_SOURCE_DIR}/tst/[^\.]*.cpp     ${PROJECT_SOURCE_DIR}/tst/[^\.]*.hpp
+    ${PROJECT_SOURCE_DIR}/example/[^\.]*.cpp ${PROJECT_SOURCE_DIR}/example/[^\.]*.hpp
 )
 
 if (CMAKE_VERSION VERSION_LESS "3.12.0")


### PR DESCRIPTION
Don't format or check copyright in files starting with `.`

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented. N/A
- [x] Adds a test for any bugs fixed. Adds tests for new features. N/A
- [x] Code is formatted
