### PR TITLE
Ensure that binaries are built before testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ add_subdirectory(src)
 add_subdirectory(example/calculate_pi)
 add_subdirectory(example/face_fields)
 add_subdirectory(example/advection)
+
 include(cmake/CheckCopyright.cmake)
 
 # Currently Ctest/Cmake doesn't ensure that tests are not stale

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,5 +182,9 @@ add_subdirectory(example/face_fields)
 add_subdirectory(example/advection)
 include(cmake/CheckCopyright.cmake)
 
+# Currently Ctest/Cmake doesn't ensure that tests are not stale
+# before running them.
+#
+# If you add tests with other binaries, add them to the DEPENDS line
 add_custom_target(checkit COMMAND ${CMAKE_CTEST_COMMAND}
                   DEPENDS unit_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,5 +180,7 @@ add_subdirectory(src)
 add_subdirectory(example/calculate_pi)
 add_subdirectory(example/face_fields)
 add_subdirectory(example/advection)
-
 include(cmake/CheckCopyright.cmake)
+
+add_custom_target(checkit COMMAND ${CMAKE_CTEST_COMMAND}
+                  DEPENDS unit_tests)


### PR DESCRIPTION
## PR Summary
Currently the 'make test' target doesn't ensure that binaries are not stale before they are run.  This is a well known issue with Cmake/Ctest.  To ensure that my test is not running with out-of-date binaries, I added a custom target "checkit" that will build the unit tests before they are run.   Normally I would use the target 'check', but that was already taken by Kokkos.

If other tests are added with different binaries, those binaries should be added to the DEPENDS line

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint N/A
- [ ] New features are documented. N/A
- [ ] Adds a test for any bugs fixed. Adds tests for new features. N/A
- [ ] Code is formatted
