### PR TITLE
fix pararray slice bug and add tests for previously broken behaviour

### DIFF
--- a/src/parthenon_arrays.hpp
+++ b/src/parthenon_arrays.hpp
@@ -280,11 +280,11 @@ class ParArrayNDGeneric {
   }
   KOKKOS_INLINE_FUNCTION
   auto SliceD(index_pair_t slc, std::integral_constant<int, 2>) const {
-    return Slice(SLC0, SLC0, SLC0, Kokkos::ALL(), slc, Kokkos::ALL());
+    return Slice(SLC0, SLC0, SLC0, SLC0, slc, Kokkos::ALL());
   }
   KOKKOS_INLINE_FUNCTION
   auto SliceD(index_pair_t slc, std::integral_constant<int, 1>) const {
-    return Slice(SLC0, SLC0, SLC0, Kokkos::ALL(), Kokkos::ALL(), slc);
+    return Slice(SLC0, SLC0, SLC0, SLC0, SLC0, slc);
   }
 #undef SLC0
 

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -270,6 +270,30 @@ TEST_CASE("ParArrayND", "[ParArrayND][Kokkos]") {
           REQUIRE(total_errors == 0);
         }
       }
+      THEN("We can slice the 2nd dimension") {
+        auto b = a.SliceD<2>(1,2);
+        AND_THEN("slices have correct values.") {
+          int total_errors = 1;
+          Kokkos::parallel_reduce(policy2d({0,0},{2,N1}),
+                                  KOKKOS_LAMBDA(const int j, const int i, int &update) {
+                                    update += (b(j,i) == a(j+1,i)) ? 0 : 1;
+                                  },
+                                  total_errors);
+          REQUIRE(total_errors == 0);
+        }
+      }
+      THEN("We can slice the 1st dimension") {
+        auto b = a.SliceD<1>(1, N1-1);
+        AND_THEN("Slices have correct values.") {
+          int total_errors = 1;
+          Kokkos::parallel_reduce(N1-1,
+                                  KOKKOS_LAMBDA(const int i, int &update) {
+                                    update += (b(i) == a(i+1)) ? 0 : 1;
+                                  },
+                                  total_errors);
+          REQUIRE(total_errors == 0);
+        }
+      }
     }
   }
 }

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -271,26 +271,28 @@ TEST_CASE("ParArrayND", "[ParArrayND][Kokkos]") {
         }
       }
       THEN("We can slice the 2nd dimension") {
-        auto b = a.SliceD<2>(1,2);
+        auto b = a.SliceD<2>(1, 2);
         AND_THEN("slices have correct values.") {
           int total_errors = 1;
-          Kokkos::parallel_reduce(policy2d({0,0},{2,N1}),
-                                  KOKKOS_LAMBDA(const int j, const int i, int &update) {
-                                    update += (b(j,i) == a(j+1,i)) ? 0 : 1;
-                                  },
-                                  total_errors);
+          Kokkos::parallel_reduce(
+              policy2d({0, 0}, {2, N1}),
+              KOKKOS_LAMBDA(const int j, const int i, int &update) {
+                update += (b(j, i) == a(j + 1, i)) ? 0 : 1;
+              },
+              total_errors);
           REQUIRE(total_errors == 0);
         }
       }
       THEN("We can slice the 1st dimension") {
-        auto b = a.SliceD<1>(1, N1-1);
+        auto b = a.SliceD<1>(1, N1 - 1);
         AND_THEN("Slices have correct values.") {
           int total_errors = 1;
-          Kokkos::parallel_reduce(N1-1,
-                                  KOKKOS_LAMBDA(const int i, int &update) {
-                                    update += (b(i) == a(i+1)) ? 0 : 1;
-                                  },
-                                  total_errors);
+          Kokkos::parallel_reduce(
+              N1 - 1,
+              KOKKOS_LAMBDA(const int i, int &update) {
+                update += (b(i) == a(i + 1)) ? 0 : 1;
+              },
+              total_errors);
           REQUIRE(total_errors == 0);
         }
       }
@@ -341,6 +343,19 @@ TEST_CASE("ParArrayND with LayoutLeft", "[ParArrayND][Kokkos][LayoutLeft]") {
               policy3d({0, 0, 0}, {2, N2, N1}),
               KOKKOS_LAMBDA(const int k, const int j, const int i, int &update) {
                 update += (b(k, j, i) == a(k + 1, j, i)) ? 0 : 1;
+              },
+              total_errors);
+          REQUIRE(total_errors == 0);
+        }
+      }
+      THEN("We can slice the 1st dimension") {
+        auto b = a.SliceD<1>(1, N1 - 1);
+        AND_THEN("Slices have correct values.") {
+          int total_errors = 1;
+          Kokkos::parallel_reduce(
+              N1 - 1,
+              KOKKOS_LAMBDA(const int i, int &update) {
+                update += (b(i) == a(i + 1)) ? 0 : 1;
               },
               total_errors);
           REQUIRE(total_errors == 0);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In issue #135 @pgrete found a bug in the implementation of slicing for `ParArrayND`. In particular, the slices into the given dimensions were wrong. Some `Kokkos::ALL()`s should have been `SLC0`s. 

I fixed the bug and added tests for those two slice use cases to ensure that the behavior is caught if it breaks again.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented. (no new features)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
