### PR TITLE
fix mysteriously outdated regression test input

### DIFF
--- a/tst/regression/test_suites/calculate_pi/parthinput.regression
+++ b/tst/regression/test_suites/calculate_pi/parthinput.regression
@@ -15,16 +15,13 @@
 #  the public, perform publicly and display publicly, and to permit others to do so.
 # ========================================================================================
 
-<comment>
-problem = Calculate PI with AMR !
-
-<job>
+<parthenon/job>
 problem_id = pi_calculator
 
-<mesh>
+<parthenon/mesh>
 refinement = adaptive
-num_threads = 4
 numlevel = 5
+num_threads=4
 
 nx1 = 64
 x1min = -2.0
@@ -42,28 +39,21 @@ nx3 = 1
 x3min = -0.5
 x3max = 0.5
 
-<meshblock>
+<parthenon/meshblock>
 nx1 = 8
 nx2 = 8
 nx3 = 1
 
-<Refinement0>
+<parthenon/refinement0>
 field = in_or_out               # the name of the variable we want to refine on
 method = derivative_order_1     # selects the first derivative method
 refine_tol = 0.5                # tag for refinement if |(dfield/dx)/field| > refine_tol
 derefine_tol = 0.05             # tag for derefinement if |(dfield/dx)/field| < derefine_tol
 max_level = 2                   # if set, limits refinement level from this criteria to no greater than max_level
 
-<output1>
-file_type = hdf5
-dt = 1.0
-variable = prim
-
-<time>
-tlim = 1.0
-
 <Pi>
 radius = 1.5
 
-<graphics>
+<parthenon/output0>
+file_type = hdf5
 variables = in_or_out


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Somehow the updated parthinput.regression for the calculate_pi regression test didn't make it into master, leading to test failures.

I'm going to merge this in as soon as the tests pass.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
