### PR TITLE
Nested Parallel For

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,8 @@ is sufficient with a link to a more detailed description in a separate [file](fe
 An arbitrary-dimensional wrapper for `Kokkos::Views` is available as
 `ParArrayND`. See documentation [here](parthenon_arrays.md).
 
+The wrappers `par_outer_for` and `par_inner_for` provide a nested parallelism interface that is needed for managing memory cached in tightly nested loops. The wrappers are documented [here](nested_par_for.md).
+
 ### State Management
 [Full Documentation](interface/state.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@ is sufficient with a link to a more detailed description in a separate [file](fe
 An arbitrary-dimensional wrapper for `Kokkos::Views` is available as
 `ParArrayND`. See documentation [here](parthenon_arrays.md).
 
-The wrappers `par_outer_for` and `par_inner_for` provide a nested parallelism interface that is needed for managing memory cached in tightly nested loops. The wrappers are documented [here](nested_par_for.md).
+The wrappers `par_for_outer` and `par_for_inner` provide a nested parallelism interface that is needed for managing memory cached in tightly nested loops. The wrappers are documented [here](nested_par_for.md).
 
 ### State Management
 [Full Documentation](interface/state.md)

--- a/docs/nested_par_for.md
+++ b/docs/nested_par_for.md
@@ -1,0 +1,30 @@
+
+# Nested Parallelism
+
+The loop wrappers documented here abstracts a hierarchical parallelism model,
+which allows more fine grain control on core level vs. vector level parallelism
+and allows explicitly defined caches for tightly nested loops. These wrappers
+provide a simplified interface of the [hierarchical parallelism in
+Kokkos](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism)
+
+## `par_outer_for`
+
+`par_outer_for` abstracts the team or multicore parallelism for outer loops.
+Inside the loop body, in the lambda function provided to `par_outer_for`,
+synchronization and memory sharing between the threads in the single team is
+possible through the `member_type` team member type from Kokkos.
+
+The bytes of scratch memory for cache needed by a single team is specified via
+the `scratch_size_in_bytes`, which needs be computed using `shmem_size` from
+the Kokkos API.
+
+The argument `scratch_level` defines where the scratch memory should be
+allocated. For CUDA GPUs, `scratch_level=0` allocates the cache in the faster
+by smaller `shared` memory and `scratch_level=1` allocates the cache in the
+slower but larger `global` or on device RAM memory. For CPUs, currently
+`scratch_level` makes no difference.
+
+
+## `par_inner_for`
+
+`par_inner_for` abstracts the vector level parallelism of compute units within a team.

--- a/docs/nested_par_for.md
+++ b/docs/nested_par_for.md
@@ -15,8 +15,7 @@ synchronization and memory sharing between the threads in the single team is
 possible through the `member_type` team member type from Kokkos.
 
 The bytes of scratch memory for cache needed by a single team is specified via
-the `scratch_size_in_bytes`, which needs be computed using `shmem_size` from
-the Kokkos API.
+the `scratch_size_in_bytes`, which needs be computed using `ScratchPadXD::shmem_size`.
 
 The argument `scratch_level` defines where the scratch memory should be
 allocated. For CUDA GPUs, `scratch_level=0` allocates the cache in the faster
@@ -28,3 +27,10 @@ slower but larger `global` or on device RAM memory. For CPUs, currently
 ## `par_inner_for`
 
 `par_inner_for` abstracts the vector level parallelism of compute units within a team.
+
+## `ScratchPadXD`
+
+Data type for memory in scratch pad/cache memory. Use `ScratchPadXD::shmem_size`, which is documented in [the 
+Kokkos documentation](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism) for determining scratch pad memory needs before kernel launch.
+
+

--- a/docs/nested_par_for.md
+++ b/docs/nested_par_for.md
@@ -43,6 +43,14 @@ Data type for memory in scratch pad/cache memory. Use
 documentation](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism)
 for determining scratch pad memory needs before kernel launch.
 
+## Important usage hint
+
+In order to ensure that individual threads of a team are synchronized always call
+`team_member.team_barrier();` after an `par_for_inner` if the following execution
+depends on the results of the `par_for_inner`.
+This pertains, for example, to filling a `ScratchPadXD` array in one `par_inner_for`
+and using the scratch array in the next one, see 
+[the unit test](../tst/unit/kokkos_abstraction.cpp) for sample usage.
 
 ## Cmake Options
 

--- a/docs/nested_par_for.md
+++ b/docs/nested_par_for.md
@@ -2,15 +2,19 @@
 # Nested Parallelism
 
 The loop wrappers documented here abstracts a hierarchical parallelism model,
-which allows more fine grain control on core level vs. vector level parallelism
-and allows explicitly defined caches for tightly nested loops. These wrappers
-provide a simplified interface of the [hierarchical parallelism in
-Kokkos](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism)
+which allows more fine grain control on core level vs. thread and vector level
+parallelism and allows explicitly defined caches for tightly nested loops.
+These wrappers provide a simplified interface of the [hierarchical parallelism
+in Kokkos](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism)
 
-## `par_outer_for`
 
-`par_outer_for` abstracts the team or multicore parallelism for outer loops.
-Inside the loop body, in the lambda function provided to `par_outer_for`,
+For an example of the nested parallel wrappers in use, see [the unit
+test](../tst/unit/kokkos_abstraction.cpp)
+
+## `par_for_outer`
+
+`par_for_outer` abstracts the team or multicore parallelism for outer loops.
+Inside the loop body, in the lambda function provided to `par_for_outer`,
 synchronization and memory sharing between the threads in the single team is
 possible through the `member_type` team member type from Kokkos.
 
@@ -23,14 +27,34 @@ by smaller `shared` memory and `scratch_level=1` allocates the cache in the
 slower but larger `global` or on device RAM memory. For CPUs, currently
 `scratch_level` makes no difference.
 
+Note that every thread within a team will execute code inside a `par_for_outer`
+but outside of the `par_for_inner`.
 
-## `par_inner_for`
+## `par_for_inner`
 
-`par_inner_for` abstracts the vector level parallelism of compute units within a team.
+`par_for_inner` abstracts the thread and vector level parallelism of compute
+units within a single team or core. Work defined through a `par_for_inner` will
+be distributed between individual threads and vector lanes within the team.
 
 ## `ScratchPadXD`
 
-Data type for memory in scratch pad/cache memory. Use `ScratchPadXD::shmem_size`, which is documented in [the 
-Kokkos documentation](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism) for determining scratch pad memory needs before kernel launch.
+Data type for memory in scratch pad/cache memory. Use
+`ScratchPadXD::shmem_size`, which is documented in [the Kokkos
+documentation](https://github.com/kokkos/kokkos/wiki/HierarchicalParallelism)
+for determining scratch pad memory needs before kernel launch.
 
 
+## Cmake Options
+
+`PAR_LOOP_INNER_LAYOUT` controls how the inner loop is implemented.
+
+`PAR_LOOP_INNER_LAYOUT=TVR_INNER_LOOP` uses the Kokkos `TeamVectorRange`, which
+merges `TeamThreadRange` and `ThreadVectorRange` into one loop, to distribute
+work between threads. `PAR_LOOP_INNER_LAYOUT=TVR_INNER_LOOP` is the only option
+supported for CUDA since the Kokkos loops are required for parallelization on
+GPUs.
+
+`PAR_LOOP_INNER_LAYOUT=SIMDFOR_INNER_LOOP` uses a `for` loop with a `#pragma
+omp simd` to vectorize the loop, which typically gives better vectorization
+loops than `PAR_LOOP_INNER_LAYOUT=TVR_INNER_LOOP` on CPUs and so is the default
+on CPUs.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,10 +41,10 @@ if (${Kokkos_ENABLE_CUDA})
   set(PAR_LOOP_LAYOUT_VALUES "MANUAL1D_LOOP;MDRANGE_LOOP;TPTTR_LOOP;TPTTRTVR_LOOP"
     CACHE STRING "Possible loop layout options.")
 
-  set(PAR_INNER_LOOP_LAYOUT "TTR_INNER_LOOP" CACHE STRING
-    "Default loop layout for par_inner_for wrapper")
+  set(PAR_LOOP_INNER_LAYOUT "TVR_INNER_LOOP" CACHE STRING
+    "Default loop layout for par_for_inner wrapper")
 
-  set(PAR_INNER_LOOP_LAYOUT_VALUES "TTR_INNER_LOOP"
+  set(PAR_LOOP_INNER_LAYOUT_VALUES "TVR_INNER_LOOP"
     CACHE STRING "Possible inner loop layout options.")
 
 elseif(${Kokkos_ENABLE_HPX})
@@ -57,21 +57,21 @@ else()
   set(PAR_LOOP_LAYOUT_VALUES "SIMDFOR_LOOP;MANUAL1D_LOOP;MDRANGE_LOOP;TPTTR_LOOP;TPTVR_LOOP;TPTTRTVR_LOOP"
     CACHE STRING "Possible loop layout options.")
 
-  set(PAR_INNER_LOOP_LAYOUT "SIMDFOR_INNER_LOOP" CACHE STRING
-    "Default loop layout for par_inner_for wrapper")
+  set(PAR_LOOP_INNER_LAYOUT "SIMDFOR_INNER_LOOP" CACHE STRING
+    "Default loop layout for par_for_inner wrapper")
 
-  set(PAR_INNER_LOOP_LAYOUT_VALUES "SIMDFOR_INNER_LOOP;TTR_INNER_LOOP"
+  set(PAR_LOOP_INNER_LAYOUT_VALUES "SIMDFOR_INNER_LOOP;TVR_INNER_LOOP"
     CACHE STRING "Possible inner loop layout options.")
 
 endif()
 
 set_property(CACHE PAR_LOOP_LAYOUT PROPERTY STRINGS ${PAR_LOOP_LAYOUT_VALUES})
 
-set_property(CACHE PAR_INNER_LOOP_LAYOUT PROPERTY STRINGS ${PAR_INNER_LOOP_LAYOUT_VALUES})
+set_property(CACHE PAR_LOOP_INNER_LAYOUT PROPERTY STRINGS ${PAR_LOOP_INNER_LAYOUT_VALUES})
 
 message(STATUS "PAR_LOOP_LAYOUT='${PAR_LOOP_LAYOUT}' (default par_for wrapper layout)")
 
-message(STATUS "PAR_INNER_LOOP_LAYOUT='${PAR_INNER_LOOP_LAYOUT}' (default par_inner_for wrapper layout)")
+message(STATUS "PAR_LOOP_INNER_LAYOUT='${PAR_LOOP_INNER_LAYOUT}' (default par_for_inner wrapper layout)")
 
 set(EXCEPTION_HANDLING_OPTION ENABLE_EXCEPTIONS) # TODO: Add option to disable exceptions
 set(COMPILED_WITH ${CMAKE_CXX_COMPILER})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,12 @@ if (${Kokkos_ENABLE_CUDA})
   set(PAR_LOOP_LAYOUT_VALUES "MANUAL1D_LOOP;MDRANGE_LOOP;TPTTR_LOOP;TPTTRTVR_LOOP"
     CACHE STRING "Possible loop layout options.")
 
+  set(PAR_INNER_LOOP_LAYOUT "TTR_INNER_LOOP" CACHE STRING
+    "Default loop layout for par_inner_for wrapper")
+
+  set(PAR_INNER_LOOP_LAYOUT_VALUES "TTR_INNER_LOOP"
+    CACHE STRING "Possible inner loop layout options.")
+
 elseif(${Kokkos_ENABLE_HPX})
   message( FATAL_ERROR "Need to add/fix/test default loop layouts for HPX backend.")
 
@@ -51,11 +57,21 @@ else()
   set(PAR_LOOP_LAYOUT_VALUES "SIMDFOR_LOOP;MANUAL1D_LOOP;MDRANGE_LOOP;TPTTR_LOOP;TPTVR_LOOP;TPTTRTVR_LOOP"
     CACHE STRING "Possible loop layout options.")
 
+  set(PAR_INNER_LOOP_LAYOUT "SIMDFOR_INNER_LOOP" CACHE STRING
+    "Default loop layout for par_inner_for wrapper")
+
+  set(PAR_INNER_LOOP_LAYOUT_VALUES "SIMDFOR_INNER_LOOP;TTR_INNER_LOOP"
+    CACHE STRING "Possible inner loop layout options.")
+
 endif()
 
 set_property(CACHE PAR_LOOP_LAYOUT PROPERTY STRINGS ${PAR_LOOP_LAYOUT_VALUES})
 
+set_property(CACHE PAR_INNER_LOOP_LAYOUT PROPERTY STRINGS ${PAR_INNER_LOOP_LAYOUT_VALUES})
+
 message(STATUS "PAR_LOOP_LAYOUT='${PAR_LOOP_LAYOUT}' (default par_for wrapper layout)")
+
+message(STATUS "PAR_INNER_LOOP_LAYOUT='${PAR_INNER_LOOP_LAYOUT}' (default par_inner_for wrapper layout)")
 
 set(EXCEPTION_HANDLING_OPTION ENABLE_EXCEPTIONS) # TODO: Add option to disable exceptions
 set(COMPILED_WITH ${CMAKE_CXX_COMPILER})

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -35,6 +35,7 @@ using DevMemSpace = Kokkos::DefaultExecutionSpace::memory_space;
 using HostMemSpace = Kokkos::HostSpace;
 using DevExecSpace = Kokkos::DefaultExecutionSpace;
 #endif
+using ScratchMemSpace = Kokkos::DefaultExecutionSpace::scratch_memory_space;
 
 using LayoutWrapper = Kokkos::LayoutRight;
 
@@ -53,6 +54,19 @@ using ParArray6D = Kokkos::View<T ******, LayoutWrapper, DevMemSpace>;
 
 using team_policy = Kokkos::TeamPolicy<>;
 using member_type = Kokkos::TeamPolicy<>::member_type;
+
+template <typename T>
+using ScratchPad1D = Kokkos::View< T*, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+template <typename T>
+using ScratchPad2D = Kokkos::View< T**, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+template <typename T>
+using ScratchPad3D = Kokkos::View< T***, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+template <typename T>
+using ScratchPad4D = Kokkos::View< T****, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+template <typename T>
+using ScratchPad5D = Kokkos::View< T*****, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+template <typename T>
+using ScratchPad6D = Kokkos::View< T******, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
 // Defining tags to determine loop_patterns using a tag dispatch design pattern
 static struct LoopPatternSimdFor {

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -504,15 +504,17 @@ inline void par_for_outer(OuterLoopPatternTeams, const std::string &name,
 
 // Inner parallel loop using TeamThreamRange
 template <typename Function>
-inline void par_for_inner(InnerLoopPatternTVR, team_mbr_t team_member, const int il,
-                          const int iu, const Function &function) {
+KOKKOS_INLINE_FUNCTION void par_for_inner(InnerLoopPatternTVR, team_mbr_t team_member,
+                                          const int il, const int iu,
+                                          const Function &function) {
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team_member, il, iu + 1), function);
 }
 
 // Inner parallel loop using FOR SIMD
 template <typename Function>
-inline void par_for_inner(InnerLoopPatternSimdFor, team_mbr_t team_member, const int il,
-                          const int iu, const Function &function) {
+KOKKOS_INLINE_FUNCTION void par_for_inner(InnerLoopPatternSimdFor, team_mbr_t team_member,
+                                          const int il, const int iu,
+                                          const Function &function) {
 #pragma omp simd
   for (int i = il; i <= iu; i++) {
     function(i);

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -154,6 +154,7 @@ inline void par_for(const std::string &name, DevExecSpace exec_space, const int 
 template <typename Function>
 inline void par_outer_for(
                 const std::string & name,
+                DevExecSpace exec_space,
                 size_t scratch_size_in_bytes,
                 const int scratch_level,
                 const int kl, const int ku,
@@ -167,13 +168,14 @@ inline void par_outer_for(
 template <typename Function>
 inline void par_outer_for(
                 const std::string & name,
+                DevExecSpace exec_space,
                 size_t scratch_size_in_bytes,
                 const int scratch_level,
                 const int nl, const int nu,
                 const int kl, const int ku,
                 const int jl, const int ju,
                 Function function) {
-  par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, scratch_size_in_bytes, 
+  par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, exec_space, scratch_size_in_bytes, 
       scratch_level, nl, nu, jl, ju, function);
 }
 
@@ -446,6 +448,7 @@ inline void par_for(LoopPatternSimdFor, const std::string &name, DevExecSpace ex
 template <typename Function>
 inline void par_outer_for(OuterLoopPatternTeams,
                 const std::string & name,
+                DevExecSpace exec_space,
                 size_t scratch_size_in_bytes,
                 const int scratch_level,
                 const int kl, const int ku,
@@ -456,7 +459,7 @@ inline void par_outer_for(OuterLoopPatternTeams,
   const int Nj = ju + 1 - jl;
   const int NkNj = Nk*Nj;
 
-  team_policy policy(NkNj);
+  team_policy policy(exec_space,NkNj,Kokkos::AUTO);
 
   Kokkos::parallel_for(name,
     policy.set_scratch_size(scratch_level,Kokkos::PerTeam(scratch_size_in_bytes)),
@@ -471,6 +474,7 @@ inline void par_outer_for(OuterLoopPatternTeams,
 template <typename Function>
 inline void par_outer_for(OuterLoopPatternTeams,
                 const std::string & name,
+                DevExecSpace exec_space,
                 size_t scratch_size_in_bytes,
                 const int scratch_level,
                 const int nl, const int nu, const int kl, const int ku, const int jl,
@@ -482,7 +486,7 @@ inline void par_outer_for(OuterLoopPatternTeams,
   const int NkNj = Nk * Nj;
   const int NnNkNj = Nn * Nk * Nj;
 
-  team_policy policy(NnNkNj);
+  team_policy policy(exec_space,NnNkNj,Kokkos::AUTO);
 
   Kokkos::parallel_for(name,
     policy.set_scratch_size(scratch_level,Kokkos::PerTeam(scratch_size_in_bytes)),

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -35,7 +35,7 @@ using DevMemSpace = Kokkos::DefaultExecutionSpace::memory_space;
 using HostMemSpace = Kokkos::HostSpace;
 using DevExecSpace = Kokkos::DefaultExecutionSpace;
 #endif
-using ScratchMemSpace = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+using ScratchMemSpace = DevExecSpace::scratch_memory_space;
 
 using LayoutWrapper = Kokkos::LayoutRight;
 
@@ -175,8 +175,8 @@ inline void par_for_outer(const std::string &name, DevExecSpace exec_space,
                           size_t scratch_size_in_bytes, const int scratch_level,
                           const int kl, const int ku, const int jl, const int ju,
                           const Function &function) {
-  par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, name, scratch_size_in_bytes, scratch_level,
-                kl, ku, jl, ju, function);
+  par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, name, exec_space, scratch_size_in_bytes,
+                scratch_level, kl, ku, jl, ju, function);
 }
 
 // 3D Outer loop default pattern
@@ -186,7 +186,7 @@ inline void par_for_outer(const std::string &name, DevExecSpace exec_space,
                           const int nl, const int nu, const int kl, const int ku,
                           const int jl, const int ju, const Function &function) {
   par_for_outer(DEFAULT_OUTER_LOOP_PATTERN, name, exec_space, scratch_size_in_bytes,
-                scratch_level, nl, nu, jl, ju, function);
+                scratch_level, nl, nu, kl, ku, jl, ju, function);
 }
 
 // Inner loop default pattern

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -76,7 +76,7 @@ static struct OuterLoopPatternTeams {
 static struct InnerLoopPatternTTR {
 } inner_loop_pattern_ttr_tag;
 static struct InnerLoopPatternSimdFor {
-} inner_loop_pattern_simd_for_tag;
+} inner_loop_pattern_simdfor_tag;
 
 
 // TODO(pgrete) I don't like this and would prefer to make the default a
@@ -108,7 +108,7 @@ static struct InnerLoopPatternSimdFor {
 #ifdef TVR_INNER_LOOP
 #define DEFAULT_INNER_LOOP_PATTERN inner_loop_pattern_ttr_tag
 #elif SIMDFOR_INNER_LOOP
-#define DEFAULT_INNER_LOOP_PATTERN inner_loop_pattern_simd_for_tag
+#define DEFAULT_INNER_LOOP_PATTERN inner_loop_pattern_simdfor_tag
 #else
 #define DEFAULT_INNER_LOOP_PATTERN loop_pattern_undefined_tag
 #endif
@@ -159,7 +159,7 @@ inline void par_outer_for(
                 const int scratch_level,
                 const int kl, const int ku,
                 const int jl, const int ju,
-                Function function) {
+                const Function &function) {
   par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, scratch_size_in_bytes, 
       scratch_level, kl, ku, jl, ju, function);
 }
@@ -174,7 +174,7 @@ inline void par_outer_for(
                 const int nl, const int nu,
                 const int kl, const int ku,
                 const int jl, const int ju,
-                Function function) {
+                const Function &function) {
   par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, exec_space, scratch_size_in_bytes, 
       scratch_level, nl, nu, jl, ju, function);
 }
@@ -184,7 +184,7 @@ template <typename Function>
 inline void par_inner_for( 
     member_type team_member,
     const int il, const int iu,
-    Function function){
+    const Function &function){
   par_inner_for(DEFAULT_INNER_LOOP_PATTERN,team_member, il, iu, function);
 }
 
@@ -453,7 +453,7 @@ inline void par_outer_for(OuterLoopPatternTeams,
                 const int scratch_level,
                 const int kl, const int ku,
                 const int jl, const int ju,
-                Function function) {
+                const Function &function) {
 
   const int Nk = ku + 1 - kl;
   const int Nj = ju + 1 - jl;
@@ -478,7 +478,7 @@ inline void par_outer_for(OuterLoopPatternTeams,
                 size_t scratch_size_in_bytes,
                 const int scratch_level,
                 const int nl, const int nu, const int kl, const int ku, const int jl,
-                const int ju, const int il, const int iu, const Function &function) {
+                const int ju, const Function &function) {
 
   const int Nn = nu - nl + 1;
   const int Nk = ku - kl + 1;
@@ -508,7 +508,7 @@ inline void par_inner_for(
     InnerLoopPatternTTR,
     member_type team_member,
     const int il, const int iu,
-    Function function){
+    const Function &function){
   Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team_member,il,iu+1),
       function);
@@ -520,7 +520,7 @@ inline void par_inner_for(
     InnerLoopPatternSimdFor,
     member_type team_member,
     const int il, const int iu,
-    Function function){
+    const Function &function){
   #pragma omp simd
   for(int i = il; i <= iu; i++){
       function(i);

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -56,17 +56,23 @@ using team_policy = Kokkos::TeamPolicy<>;
 using member_type = Kokkos::TeamPolicy<>::member_type;
 
 template <typename T>
-using ScratchPad1D = Kokkos::View< T*, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+using ScratchPad1D = Kokkos::View<T *, LayoutWrapper, ScratchMemSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 template <typename T>
-using ScratchPad2D = Kokkos::View< T**, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+using ScratchPad2D = Kokkos::View<T **, LayoutWrapper, ScratchMemSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 template <typename T>
-using ScratchPad3D = Kokkos::View< T***, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+using ScratchPad3D = Kokkos::View<T ***, LayoutWrapper, ScratchMemSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 template <typename T>
-using ScratchPad4D = Kokkos::View< T****, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+using ScratchPad4D = Kokkos::View<T ****, LayoutWrapper, ScratchMemSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 template <typename T>
-using ScratchPad5D = Kokkos::View< T*****, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+using ScratchPad5D = Kokkos::View<T *****, LayoutWrapper, ScratchMemSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 template <typename T>
-using ScratchPad6D = Kokkos::View< T******, LayoutWrapper, ScratchMemSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+using ScratchPad6D = Kokkos::View<T ******, LayoutWrapper, ScratchMemSpace,
+                                  Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
 // Defining tags to determine loop_patterns using a tag dispatch design pattern
 static struct LoopPatternSimdFor {
@@ -84,14 +90,13 @@ static struct LoopPatternTPTTRTVR {
 static struct LoopPatternUndefined {
 } loop_pattern_undefined_tag;
 
-//Tags for Nested parallelism
+// Tags for Nested parallelism
 static struct OuterLoopPatternTeams {
 } outer_loop_pattern_teams_tag;
 static struct InnerLoopPatternTTR {
 } inner_loop_pattern_ttr_tag;
 static struct InnerLoopPatternSimdFor {
 } inner_loop_pattern_simdfor_tag;
-
 
 // TODO(pgrete) I don't like this and would prefer to make the default a
 // parameter that is read from the parameter file rather than a compile time
@@ -166,40 +171,29 @@ inline void par_for(const std::string &name, DevExecSpace exec_space, const int 
 
 // 2D Outer loop default pattern
 template <typename Function>
-inline void par_outer_for(
-                const std::string & name,
-                DevExecSpace exec_space,
-                size_t scratch_size_in_bytes,
-                const int scratch_level,
-                const int kl, const int ku,
-                const int jl, const int ju,
-                const Function &function) {
-  par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, scratch_size_in_bytes, 
-      scratch_level, kl, ku, jl, ju, function);
+inline void par_outer_for(const std::string &name, DevExecSpace exec_space,
+                          size_t scratch_size_in_bytes, const int scratch_level,
+                          const int kl, const int ku, const int jl, const int ju,
+                          const Function &function) {
+  par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, scratch_size_in_bytes, scratch_level,
+                kl, ku, jl, ju, function);
 }
 
 // 3D Outer loop default pattern
 template <typename Function>
-inline void par_outer_for(
-                const std::string & name,
-                DevExecSpace exec_space,
-                size_t scratch_size_in_bytes,
-                const int scratch_level,
-                const int nl, const int nu,
-                const int kl, const int ku,
-                const int jl, const int ju,
-                const Function &function) {
-  par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, exec_space, scratch_size_in_bytes, 
-      scratch_level, nl, nu, jl, ju, function);
+inline void par_outer_for(const std::string &name, DevExecSpace exec_space,
+                          size_t scratch_size_in_bytes, const int scratch_level,
+                          const int nl, const int nu, const int kl, const int ku,
+                          const int jl, const int ju, const Function &function) {
+  par_outer_for(DEFAULT_OUTER_LOOP_PATTERN, name, exec_space, scratch_size_in_bytes,
+                scratch_level, nl, nu, jl, ju, function);
 }
 
 // Inner loop default pattern
 template <typename Function>
-inline void par_inner_for( 
-    member_type team_member,
-    const int il, const int iu,
-    const Function &function){
-  par_inner_for(DEFAULT_INNER_LOOP_PATTERN,team_member, il, iu, function);
+inline void par_inner_for(member_type team_member, const int il, const int iu,
+                          const Function &function) {
+  par_inner_for(DEFAULT_INNER_LOOP_PATTERN, team_member, il, iu, function);
 }
 
 // 1D loop using MDRange loops
@@ -456,43 +450,36 @@ inline void par_for(LoopPatternSimdFor, const std::string &name, DevExecSpace ex
   Kokkos::Profiling::popRegion();
 }
 
-
-
 // 2D  outer parallel loop using Kokkos Teams
 template <typename Function>
-inline void par_outer_for(OuterLoopPatternTeams,
-                const std::string & name,
-                DevExecSpace exec_space,
-                size_t scratch_size_in_bytes,
-                const int scratch_level,
-                const int kl, const int ku,
-                const int jl, const int ju,
-                const Function &function) {
+inline void par_outer_for(OuterLoopPatternTeams, const std::string &name,
+                          DevExecSpace exec_space, size_t scratch_size_in_bytes,
+                          const int scratch_level, const int kl, const int ku,
+                          const int jl, const int ju, const Function &function) {
 
   const int Nk = ku + 1 - kl;
   const int Nj = ju + 1 - jl;
-  const int NkNj = Nk*Nj;
+  const int NkNj = Nk * Nj;
 
-  team_policy policy(exec_space,NkNj,Kokkos::AUTO);
+  team_policy policy(exec_space, NkNj, Kokkos::AUTO);
 
-  Kokkos::parallel_for(name,
-    policy.set_scratch_size(scratch_level,Kokkos::PerTeam(scratch_size_in_bytes)),
-    KOKKOS_LAMBDA (member_type team_member) {
-      const int k = team_member.league_rank() / Nk + kl;
-      const int j = team_member.league_rank() % Nj + jl;
-      function(team_member,k,j);
-    });
+  Kokkos::parallel_for(
+      name,
+      policy.set_scratch_size(scratch_level, Kokkos::PerTeam(scratch_size_in_bytes)),
+      KOKKOS_LAMBDA(member_type team_member) {
+        const int k = team_member.league_rank() / Nk + kl;
+        const int j = team_member.league_rank() % Nj + jl;
+        function(team_member, k, j);
+      });
 }
 
 // 3D  outer parallel loop using Kokkos Teams
 template <typename Function>
-inline void par_outer_for(OuterLoopPatternTeams,
-                const std::string & name,
-                DevExecSpace exec_space,
-                size_t scratch_size_in_bytes,
-                const int scratch_level,
-                const int nl, const int nu, const int kl, const int ku, const int jl,
-                const int ju, const Function &function) {
+inline void par_outer_for(OuterLoopPatternTeams, const std::string &name,
+                          DevExecSpace exec_space, size_t scratch_size_in_bytes,
+                          const int scratch_level, const int nl, const int nu,
+                          const int kl, const int ku, const int jl, const int ju,
+                          const Function &function) {
 
   const int Nn = nu - nl + 1;
   const int Nk = ku - kl + 1;
@@ -500,48 +487,37 @@ inline void par_outer_for(OuterLoopPatternTeams,
   const int NkNj = Nk * Nj;
   const int NnNkNj = Nn * Nk * Nj;
 
-  team_policy policy(exec_space,NnNkNj,Kokkos::AUTO);
+  team_policy policy(exec_space, NnNkNj, Kokkos::AUTO);
 
-  Kokkos::parallel_for(name,
-    policy.set_scratch_size(scratch_level,Kokkos::PerTeam(scratch_size_in_bytes)),
-    KOKKOS_LAMBDA (member_type team_member) {
+  Kokkos::parallel_for(
+      name,
+      policy.set_scratch_size(scratch_level, Kokkos::PerTeam(scratch_size_in_bytes)),
+      KOKKOS_LAMBDA(member_type team_member) {
         int n = team_member.league_rank() / NkNj;
         int k = (team_member.league_rank() - n * NkNj) / Nj;
         const int j = team_member.league_rank() - n * NkNj - k * Nj + jl;
         n += nl;
         k += kl;
-      function(team_member,n,k,j);
-    });
+        function(team_member, n, k, j);
+      });
 }
-
-
 
 // Inner parallel loop using TeamThreamRange
 template <typename Function>
-inline void par_inner_for( 
-    InnerLoopPatternTTR,
-    member_type team_member,
-    const int il, const int iu,
-    const Function &function){
-  Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team_member,il,iu+1),
-      function);
+inline void par_inner_for(InnerLoopPatternTTR, member_type team_member, const int il,
+                          const int iu, const Function &function) {
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team_member, il, iu + 1), function);
 }
 
 // Inner parallel loop using FOR SIMD
 template <typename Function>
-inline void par_inner_for( 
-    InnerLoopPatternSimdFor,
-    member_type team_member,
-    const int il, const int iu,
-    const Function &function){
-  #pragma omp simd
-  for(int i = il; i <= iu; i++){
-      function(i);
+inline void par_inner_for(InnerLoopPatternSimdFor, member_type team_member, const int il,
+                          const int iu, const Function &function) {
+#pragma omp simd
+  for (int i = il; i <= iu; i++) {
+    function(i);
   }
 }
-
-
 
 // reused from kokoks/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
 // commit a0d011fb30022362c61b3bb000ae3de6906cb6a7

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -171,6 +171,25 @@ class MeshBlock {
     parthenon::par_for(name, exec_space, nl, nu, kl, ku, jl, ju, il, iu, function);
   }
 
+  // 2D Outer default loop pattern
+  template <typename Function>
+  inline void par_for_outer(const std::string &name, const size_t &scratch_size_in_bytes,
+                            const int &scratch_level, const int &kl, const int &ku,
+                            const int &jl, const int &ju, const Function &function) {
+    parthenon::par_for_outer(name, exec_space, scratch_size_in_bytes, scratch_level, kl,
+                             ku, jl, ju, function);
+  }
+
+  // 3D Outer default loop pattern
+  template <typename Function>
+  inline void par_for(const std::string &name, size_t &scratch_size_in_bytes,
+                      const int &scratch_level, const int &nl, const int &nu,
+                      const int &kl, const int &ku, const int &jl, const int &ju,
+                      const Function &function) {
+    parthenon::par_for_outer(name, exec_space, scratch_size_in_bytes, scratch_level, nl,
+                             nu, kl, ku, jl, ju, function);
+  }
+
   std::size_t GetBlockSizeInBytes();
   int GetNumberOfMeshBlockCells() {
     return block_size.nx1 * block_size.nx2 * block_size.nx3;

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -279,7 +279,7 @@ bool test_wrapper_nested_3d(OuterLoopPattern outer_loop_pattern,
     for (int k = 0; k < N; k++)
       for (int j = 0; j < N; j++)
         for (int i = 0; i < N; i++)
-          host_u(k, j, i) = pow((i + 1) * (j + 1) * (k + 1), 2.0);
+          host_u(k, j, i) = pow((i + 1) * (j + 2) * (k + 3), 2.0);
 
   // Copy host array content to device
   Kokkos::deep_copy(dev_u, host_u);
@@ -319,8 +319,8 @@ bool test_wrapper_nested_3d(OuterLoopPattern outer_loop_pattern,
   for (int k = 0; k < N; k++) {
     for (int j = 0; j < N; j++) {
       for (int i = 1; i < N - 1; i++) {
-        const Real analytic = 2.0 * (i + 1) * pow((j + 1) * (k + 1), 2.0);
-        const Real err = host_du(j, k, i - 1) - analytic;
+        const Real analytic = 2.0 * (i + 1) * pow((j + 2) * (k + 3), 2.0);
+        const Real err = host_du(k, j, i - 1) - analytic;
 
         max_rel_err = fmax(fabs(err / analytic), max_rel_err);
       }
@@ -347,7 +347,7 @@ bool test_wrapper_nested_4d(OuterLoopPattern outer_loop_pattern,
     for (int k = 0; k < N; k++)
       for (int j = 0; j < N; j++)
         for (int i = 0; i < N; i++)
-          host_u(n, k, j, i) = pow((i + 1) * (j + 1) * (k + 1) * (n + 1), 2.0);
+          host_u(n, k, j, i) = pow((i + 1) * (j + 2) * (k + 3) * (n + 4), 2.0);
 
   // Copy host array content to device
   Kokkos::deep_copy(dev_u, host_u);
@@ -389,8 +389,8 @@ bool test_wrapper_nested_4d(OuterLoopPattern outer_loop_pattern,
     for (int k = 0; k < N; k++) {
       for (int j = 0; j < N; j++) {
         for (int i = 1; i < N - 1; i++) {
-          const Real analytic = 2.0 * (i + 1) * pow((j + 1) * (k + 1) * (n + 1), 2.0);
-          const Real err = host_du(n, j, k, i - 1) - analytic;
+          const Real analytic = 2.0 * (i + 1) * pow((j + 2) * (k + 3) * (n + 4), 2.0);
+          const Real err = host_du(n, k, j, i - 1) - analytic;
 
           max_rel_err = fmax(fabs(err / analytic), max_rel_err);
         }

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -262,6 +262,182 @@ TEST_CASE("par_for loops", "[wrapper]") {
   }
 }
 
+template <class OuterLoopPattern, class InnerLoopPattern>
+bool test_wrapper_nested_3d(
+    OuterLoopPattern outer_loop_pattern, InnerLoopPattern inner_loop_pattern, 
+    DevExecSpace exec_space) {
+  //Compute the 2nd order centered derivative in x of i+1^2 * j+1^2 * k+1^2
+
+  const int N = 32;
+  ParArray3D<Real> dev_u("device u", N, N, N);
+  ParArray3D<Real> dev_du("device du", N, N, N-2);
+  auto host_u = Kokkos::create_mirror(dev_u);
+  auto host_du = Kokkos::create_mirror(dev_du);
+
+  // initialize with i^2 * j^2 * k^2
+  for (int n = 0; n < N; n++)
+    for (int k = 0; k < N; k++)
+      for (int j = 0; j < N; j++)
+        for (int i = 0; i < N; i++)
+          host_u(k, j, i) = pow( (i+1)*(j+1)*(k+1),2.0);
+
+  // Copy host array content to device
+  Kokkos::deep_copy(dev_u, host_u);
+
+
+  //Compute the scratch memory needs (forrestglines): should this also be abstracted away?
+  const int scratch_level=0;
+  typedef Kokkos::DefaultExecutionSpace::scratch_memory_space ScratchSpace;
+  typedef Kokkos::View< double*, Kokkos::LayoutRight, ScratchSpace,
+                Kokkos::MemoryTraits<Kokkos::Unmanaged> >  ScratchPadView;
+  size_t scratch_size_in_bytes = ScratchPadView::shmem_size(N);
+
+  // Compute the 2nd order centered derivative in x
+  parthenon::par_outer_for(
+    outer_loop_pattern, "unit test Nested 3D", exec_space, 
+    scratch_size_in_bytes,scratch_level,
+    0, N - 1, 0, N - 1,
+
+    KOKKOS_LAMBDA(parthenon::member_type team_member, const int k, const int j) {
+      //Load a pencil in x to minimize DRAM accesses (and test scratch pad)
+      ScratchPadView scratch_u(team_member.team_scratch(scratch_level),N);
+      parthenon::par_inner_for(inner_loop_pattern, team_member,  0, N-1,
+        [&] (const int i){
+          scratch_u(i) = dev_u(k,j,i);
+        });
+      //Sync all threads in the team so that scratch memory is consistent
+      team_member.team_barrier();
+
+      //Compute the derivative from scratch memory
+      parthenon::par_inner_for(inner_loop_pattern, team_member,  1, N-2,
+        [&] (const int i){
+          dev_du(k, j, i-1) = scratch_u(i+1) -2*scratch_u(i) + scratch_u(i-1);
+      });
+    });
+
+  // Copy array back from device to host
+  Kokkos::deep_copy(host_du, dev_du);
+
+  Real max_rel_err = -1;
+  const Real rel_tol = 1e-12; // (forrestglines) magic number for machine tolerance - is there something better?
+
+  // compare data on the host
+  for (int k = 0; k < N; k++){
+    for (int j = 0; j < N; j++){
+      for (int i = 1; i < N-1; i++){
+        const Real analytic = 2.0*(i+1)*pow((j+1)*(k+1),2.0);
+        const Real err = host_du(j,k,i-1) - analytic;
+
+        max_rel_err = fmax( fabs(err/analytic),max_rel_err);
+      }
+    }
+  }
+
+
+  return max_rel_err > rel_tol;
+}
+
+template <class OuterLoopPattern, class InnerLoopPattern>
+bool test_wrapper_nested_4d(
+    OuterLoopPattern outer_loop_pattern, InnerLoopPattern inner_loop_pattern, 
+    DevExecSpace exec_space) {
+  //Compute the 2nd order centered derivative in x of i+1^2 * j+1^2 * k+1^2 * n+1^2
+
+  const int N = 32;
+  ParArray4D<Real> dev_u("device u", N, N, N, N);
+  ParArray4D<Real> dev_du("device du", N, N, N, N-2);
+  auto host_u = Kokkos::create_mirror(dev_u);
+  auto host_du = Kokkos::create_mirror(dev_du);
+
+  // initialize with i^2 * j^2 * k^2
+  for (int n = 0; n < N; n++)
+    for (int k = 0; k < N; k++)
+      for (int j = 0; j < N; j++)
+        for (int i = 0; i < N; i++)
+          host_u(n, k, j, i) = pow( (i+1)*(j+1)*(k+1)*(n+1),2.0);
+
+  // Copy host array content to device
+  Kokkos::deep_copy(dev_u, host_u);
+
+
+  //Compute the scratch memory needs (forrestglines): should this also be abstracted away?
+  const int scratch_level=0;
+  typedef Kokkos::DefaultExecutionSpace::scratch_memory_space ScratchSpace;
+  typedef Kokkos::View< double*, Kokkos::LayoutRight, ScratchSpace,
+                Kokkos::MemoryTraits<Kokkos::Unmanaged> >  ScratchPadView;
+  size_t scratch_size_in_bytes = ScratchPadView::shmem_size(N);
+
+  // Compute the 2nd order centered derivative in x
+  parthenon::par_outer_for(
+    outer_loop_pattern, "unit test Nested 4D", exec_space, 
+    scratch_size_in_bytes,scratch_level,
+    0, N - 1, 0, N - 1, 0, N - 1,
+
+    KOKKOS_LAMBDA(parthenon::member_type team_member, const int n, const int k, const int j) {
+      //Load a pencil in x to minimize DRAM accesses (and test scratch pad)
+      ScratchPadView scratch_u(team_member.team_scratch(scratch_level),N);
+      parthenon::par_inner_for(inner_loop_pattern, team_member,  0, N-1,
+        [&] (const int i){
+          scratch_u(i) = dev_u(n,k,j,i);
+        });
+      //Sync all threads in the team so that scratch memory is consistent
+      team_member.team_barrier();
+
+      //Compute the derivative from scratch memory
+      parthenon::par_inner_for(inner_loop_pattern, team_member,  1, N-2,
+        [&] (const int i){
+          dev_du(n, k, j, i-1) = scratch_u(i+1) -2*scratch_u(i) + scratch_u(i-1);
+      });
+    });
+
+  // Copy array back from device to host
+  Kokkos::deep_copy(host_du, dev_du);
+
+  Real max_rel_err = -1;
+  const Real rel_tol = 1e-12; // (forrestglines) magic number for machine tolerance - is there something better?
+
+  // compare data on the host
+  for (int n = 0; n < N; n++){
+    for (int k = 0; k < N; k++){
+      for (int j = 0; j < N; j++){
+        for (int i = 1; i < N-1; i++){
+          const Real analytic = 2.0*(i+1)*pow((j+1)*(k+1)*(n+1),2.0);
+          const Real err = host_du(n,j,k,i-1) - analytic;
+
+          max_rel_err = fmax( fabs(err/analytic),max_rel_err);
+        }
+      }
+    }
+  }
+
+
+  return max_rel_err > rel_tol;
+}
+
+TEST_CASE("nested par_for loops", "[wrapper]") {
+  auto default_exec_space = DevExecSpace();
+
+  SECTION("3D nested loops") {
+    REQUIRE(test_wrapper_nested_3d(parthenon::outer_loop_pattern_teams_tag, parthenon::inner_loop_pattern_ttr_tag, default_exec_space) ==
+            true);
+
+#ifndef KOKKOS_ENABLE_CUDA
+    REQUIRE(test_wrapper_nested_3d(parthenon::outer_loop_pattern_teams_tag, parthenon::inner_loop_pattern_simdfor_tag, default_exec_space) ==
+            true);
+#endif
+  }
+
+  SECTION("4D nested loops") {
+    REQUIRE(test_wrapper_nested_4d(parthenon::outer_loop_pattern_teams_tag, parthenon::inner_loop_pattern_ttr_tag, default_exec_space) ==
+            true);
+
+#ifndef KOKKOS_ENABLE_CUDA
+    REQUIRE(test_wrapper_nested_4d(parthenon::outer_loop_pattern_teams_tag, parthenon::inner_loop_pattern_simdfor_tag, default_exec_space) ==
+            true);
+#endif
+  }
+}
+
 struct LargeNShortTBufferPack {
   int nghost;
   int ncells; // number of cells in the linear dimension - very simplistic


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Adding nested parallel for loop abstractions `par_outer_loop` and `par_inner_loop` to abstract team level parallelisms and Kokkos scratch memory.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Adds the nested parallel for wrappers `par_outer_loop` and `par_inner_loop` that abstract elements of the Kokkos hierarchical parallelism for more convenient use on 3D and 4D grids. These wrappers allow management of cache memory which is necessary for efficient reconstruction kernels.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
