### PR TITLE
Enforce cpplint, reintroduce UserWorkAfterLoop, add VL2 integrator, fix cmd line parsing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,8 +15,8 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
 stages:
-  - style
   - short
+  - style
 
 style-check:
   tags:
@@ -24,7 +24,6 @@ style-check:
   stage: style
   script:
     - python ./tst/style/cpplint.py --counting=detailed --recursive src example tst
-  allow_failure: true
 
 parthenon-cuda-short:
   tags:

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -58,6 +58,8 @@ DriverStatus EvolutionDriver::Execute() {
     }
   } // END OF MAIN INTEGRATION LOOP ======================================================
 
+  pmesh->UserWorkAfterLoop(pinput, tm);
+
   DriverStatus status = DriverStatus::complete;
 
   pouts->MakeOutputs(pmesh, pinput, &tm);

--- a/src/driver/multistage.cpp
+++ b/src/driver/multistage.cpp
@@ -32,6 +32,11 @@ MultiStageDriver::MultiStageDriver(ParameterInput *pin, Mesh *pm)
     beta.resize(nstages);
     beta[0] = 1.0;
     beta[1] = 0.5;
+  } else if (!integrator_name.compare("vl2")) {
+    nstages = 2;
+    beta.resize(nstages);
+    beta[0] = 0.5;
+    beta[1] = 1.0;
   } else if (!integrator_name.compare("rk3")) {
     nstages = 3;
     beta.resize(nstages);

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -456,7 +456,6 @@ inline void par_for_outer(OuterLoopPatternTeams, const std::string &name,
                           DevExecSpace exec_space, size_t scratch_size_in_bytes,
                           const int scratch_level, const int kl, const int ku,
                           const int jl, const int ju, const Function &function) {
-
   const int Nk = ku + 1 - kl;
   const int Nj = ju + 1 - jl;
   const int NkNj = Nk * Nj;
@@ -480,7 +479,6 @@ inline void par_for_outer(OuterLoopPatternTeams, const std::string &name,
                           const int scratch_level, const int nl, const int nu,
                           const int kl, const int ku, const int jl, const int ju,
                           const Function &function) {
-
   const int Nn = nu - nl + 1;
   const int Nk = ku - kl + 1;
   const int Nj = ju - jl + 1;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -300,7 +300,7 @@ class Mesh {
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   void UserWorkAfterLoop(ParameterInput *pin, SimTime &tm); // called in main loop
-  void UserWorkInLoop();                       // called in main after each cycle
+  void UserWorkInLoop(); // called in main after each cycle
   int GetRootLevel() { return root_level; }
   int GetMaxLevel() { return max_level; }
   int GetCurrentLevel() { return current_level; }

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -299,7 +299,7 @@ class Mesh {
   int ReserveTagPhysIDs(int num_phys);
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
-  void UserWorkAfterLoop(ParameterInput *pin); // called in main loop
+  void UserWorkAfterLoop(ParameterInput *pin, SimTime &tm); // called in main loop
   void UserWorkInLoop();                       // called in main after each cycle
   int GetRootLevel() { return root_level; }
   int GetMaxLevel() { return max_level; }

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -418,9 +418,10 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
   bool first = true;
   OutputType *ptype = pfirst_type_;
   while (ptype != nullptr) {
-    if ((ptype->output_params.dt >= 0.0) &&
-        (tm == nullptr || (tm->time == tm->start_time) ||
-         (tm->time >= ptype->output_params.next_time) || (tm->time >= tm->tlim))) {
+    if ((tm == nullptr) ||
+        ((ptype->output_params.dt >= 0.0) &&
+         ((tm->time == tm->start_time) || (tm->time >= ptype->output_params.next_time) ||
+          (tm->time >= tm->tlim)))) {
       if (first && ptype->output_params.file_type != "hst") {
         pm->ApplyUserWorkBeforeOutput(pin);
         first = false;

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -418,8 +418,9 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
   bool first = true;
   OutputType *ptype = pfirst_type_;
   while (ptype != nullptr) {
-    if (tm == nullptr || (tm->time == tm->start_time) ||
-        (tm->time >= ptype->output_params.next_time) || (tm->time >= tm->tlim)) {
+    if ((ptype->output_params.dt >= 0.0) &&
+        (tm == nullptr || (tm->time == tm->start_time) ||
+         (tm->time >= ptype->output_params.next_time) || (tm->time >= tm->tlim))) {
       if (first && ptype->output_params.file_type != "hst") {
         pm->ApplyUserWorkBeforeOutput(pin);
         first = false;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -397,7 +397,7 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
 
   for (int i = 1; i < argc; i++) {
     input_text = argv[i];
-    std::size_t slash_posn = input_text.find_first_of("/"); // find "/" character
+    std::size_t slash_posn = input_text.rfind("/"); // find last "/" character
     std::size_t equal_posn = input_text.find_first_of("="); // find "=" character
 
     // skip if either "/" or "=" do not exist in input

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -397,7 +397,7 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
 
   for (int i = 1; i < argc; i++) {
     input_text = argv[i];
-    std::size_t slash_posn = input_text.rfind("/"); // find last "/" character
+    std::size_t slash_posn = input_text.rfind("/");         // find last "/" character
     std::size_t equal_posn = input_text.find_first_of("="); // find "=" character
 
     // skip if either "/" or "=" do not exist in input

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -57,6 +57,7 @@
 #include <stdexcept>
 
 #include "globals.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 
@@ -400,6 +401,12 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
     std::size_t slash_posn = input_text.rfind("/");         // find last "/" character
     std::size_t equal_posn = input_text.find_first_of("="); // find "=" character
 
+    if (slash_posn > equal_posn) {
+      PARTHENON_FAIL(
+          "'/' used as value (rhs of =) when modifying " + input_text + "." +
+          "Please update value of change logic in ModifyFromCmdline function.");
+    }
+
     // skip if either "/" or "=" do not exist in input
     if ((slash_posn == std::string::npos) || (equal_posn == std::string::npos)) continue;
 
@@ -414,7 +421,7 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
       msg << "### FATAL ERROR in function [ParameterInput::ModifyFromCmdline]"
           << std::endl
           << "Block name '" << block << "' on command line not found";
-      ATHENA_ERROR(msg);
+      PARTHENON_FAIL(msg.str());
     }
 
     // get pointer to node with same parameter name in singly linked list of InputLines
@@ -424,7 +431,7 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
           << std::endl
           << "Parameter '" << name << "' in block '" << block
           << "' on command line not found";
-      ATHENA_ERROR(msg);
+      PARTHENON_FAIL(msg.str());
     }
     pl->param_value.assign(value); // replace existing value
 

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -63,11 +63,11 @@ void __attribute__((weak)) Mesh::UserWorkInLoop() {
 }
 
 //========================================================================================
-//! \fn void Mesh::UserWorkAfterLoop(ParameterInput *pin)
+//! \fn void Mesh::UserWorkAfterLoop(ParameterInput *pin, SimTime &tm)
 //  \brief Function called after main loop is finished for user-defined work.
 //========================================================================================
 
-void __attribute__((weak)) Mesh::UserWorkAfterLoop(ParameterInput *pin) {
+void __attribute__((weak)) Mesh::UserWorkAfterLoop(ParameterInput *pin, SimTime &tm) {
   // do nothing
   return;
 }


### PR DESCRIPTION
## PR Summary

As the title suggest, multiple small fixes I stumbled across when integrating with AthenaPK:
- Enforce cpplint (stage is not allowed to fail any more during CI, but also run last so that regression tests will always executed first)
- reintroduce UserWorkAfterLoop (Athena++ feature that we removed from the ParthenonManager/driver infrastructure during transition -- very helpful for regression/convergence tests)
- add VL2 integrator beta (also reintroduced from original Athena++ code)
- fix cmd line parsing to override input parameter options (the addition of prefixes, such as `parthenon/time` broke the parsing based on the first occurrence of `/`. Now works for both blocks with and without prefixes).

## PR Checklist

- [x] Code passes cpplint
- [x] Code is formatted
