### PR TITLE
Fix printf in kernels

### DIFF
--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -51,19 +51,16 @@ namespace ErrorChecking {
 KOKKOS_INLINE_FUNCTION
 void require(std::string const &condition, std::string const &message,
              std::string const &filename, int const linenumber) {
-  fprintf(stderr,
-          "### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
-          "%s\n  Line number: %i\n",
-          condition.c_str(), message.c_str(), filename.c_str(), linenumber);
+  printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
+         "%s\n  Line number: %i\n",
+         condition.c_str(), message.c_str(), filename.c_str(), linenumber);
   exit(EXIT_FAILURE);
 }
 
 KOKKOS_INLINE_FUNCTION
 void fail(std::string const &message, std::string const &filename, int const linenumber) {
-  fprintf(
-      stderr,
-      "### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-      message.c_str(), filename.c_str(), linenumber);
+  printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+         message.c_str(), filename.c_str(), linenumber);
   exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
## PR Summary

`fprintf` is not available on devices. Thus, we need to use `printf` (and cannot print to stderr).

## PR Checklist

- [x] Code passes cpplint
- [x] Code is formatted
