### PR TITLE
kokkosify error checking macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(DISABLE_HDF5 "HDF5 is enabled by default if found, set this to True to di
 option(ENABLE_COMPILER_WARNINGS "Enable compiler warnings" OFF)
 option(CHECK_REGISTRY_PRESSURE "Check the registry pressure for Kokkos CUDA kernels" OFF)
 option(TEST_INTEL_OPTIMIZATION "Test intel optimization and vectorization" OFF)
+option(TEST_ERROR_CHECKING "Enables the error checking unit test. This test will FAIL" OFF)
 
 include(cmake/Format.cmake)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,11 @@ Macros for causing execution to throw an exception are provided [here](../src/ut
 * PARTHENON_DEBUG_REQUIRE(condition, message) exits if the condition does not evaluate to true when in debug mode.
 * PARTHENON_DEBUG_FAIL(message) always exits when in debug mode.
 
-Both macros print the message, and filename and line number where the macro is called. PARTHENON_REQUIRE also prints the condition.
+Both macros print the message, and filename and line number where the
+macro is called. PARTHENON_REQUIRE also prints the condition. Note
+that these macros take a C style string, not a C++ style string. This
+is a limitation of GPU compatibility. Examples of use can be found
+[here](../tst/unit/test_error_checking.cpp).
 
 
 ## Long feature description

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -13,20 +13,16 @@
 #ifndef INTERFACE_PARAMS_HPP_
 #define INTERFACE_PARAMS_HPP_
 
-#ifndef DEBUG_
-#define DEBUG_ 0
-#endif
-
 #include <iostream>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
-#if (DEBUG_ > 0)
+#ifndef NDEBUG
 #include <typeindex>
 #include <typeinfo>
-#endif
+#endif // NDEBUG
 
 #include "utils/error_checking.hpp"
 
@@ -100,14 +96,16 @@ class Params {
   template <typename T>
   void typeCheck(const std::string key, bool die) {
     // check on return type
+    // TODO(JMM): This is really clunky. Should we remove the conditional
+    // and put it in the require statement?
     if (myTypes_[key].compare(std::string(typeid(T).name()))) {
-      std::cout << "WRONG TYPE FOR KEY '" << key << "'" << std::endl;
-      PARTHENON_REQUIRE(!die, "Exit request on wrong type for key " + key);
+      std::string message = "WRONG TYPE FOR KEY '" + key + "'";
+      PARTHENON_REQUIRE(!die, message.c_str());
     }
   }
 
   void keyCheck(const std::string key, bool die) {
-#if (DEBUG_ > 0)
+#ifndef NDEBUG
     if (!hasKey(key)) {
       // key alread exists, replace
       std::cout << std::endl;
@@ -117,11 +115,10 @@ class Params {
       std::cout << "----------------------------------------------" << std::endl;
       std::cout << std::endl;
 
-      if (die) {
-        throw std::invalid_argument("Key " + key + " doesn't exist");
-      }
+      std::string message = "Key " + key + " doesn't exist";
+      PARTHENON_DEBUG_REQUIRE(!die,message.c_str());
     }
-#endif
+#endif // NDEBUG
   }
 
   std::map<std::string, std::unique_ptr<Params::base_t>> myParams_;

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -116,7 +116,7 @@ class Params {
       std::cout << std::endl;
 
       std::string message = "Key " + key + " doesn't exist";
-      PARTHENON_DEBUG_REQUIRE(!die,message.c_str());
+      PARTHENON_DEBUG_REQUIRE(!die, message.c_str());
     }
 #endif // NDEBUG
   }

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -402,9 +402,9 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
     std::size_t equal_posn = input_text.find_first_of("="); // find "=" character
 
     if (slash_posn > equal_posn) {
-      msg << "'/' used as value (rhs of =) when modifying "
-          << input_text << "." << " Please update value of change "
-          <<"logic in ModifyFromCmdline function.";
+      msg << "'/' used as value (rhs of =) when modifying " << input_text << "."
+          << " Please update value of change "
+          << "logic in ModifyFromCmdline function.";
       PARTHENON_FAIL(msg.str().c_str());
     }
 

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -402,9 +402,10 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
     std::size_t equal_posn = input_text.find_first_of("="); // find "=" character
 
     if (slash_posn > equal_posn) {
-      PARTHENON_FAIL(
-          "'/' used as value (rhs of =) when modifying " + input_text + "." +
-          "Please update value of change logic in ModifyFromCmdline function.");
+      msg << "'/' used as value (rhs of =) when modifying "
+          << input_text << "." << " Please update value of change "
+          <<"logic in ModifyFromCmdline function.";
+      PARTHENON_FAIL(msg.str().c_str());
     }
 
     // skip if either "/" or "=" do not exist in input
@@ -421,7 +422,7 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
       msg << "### FATAL ERROR in function [ParameterInput::ModifyFromCmdline]"
           << std::endl
           << "Block name '" << block << "' on command line not found";
-      PARTHENON_FAIL(msg.str());
+      PARTHENON_FAIL(msg.str().c_str());
     }
 
     // get pointer to node with same parameter name in singly linked list of InputLines
@@ -431,7 +432,7 @@ void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
           << std::endl
           << "Parameter '" << name << "' in block '" << block
           << "' on command line not found";
-      PARTHENON_FAIL(msg.str());
+      PARTHENON_FAIL(msg.str().c_str());
     }
     pl->param_value.assign(value); // replace existing value
 

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -20,8 +20,6 @@
 //  \brief utility macros for error checking
 
 #include <iostream>
-#include <stdexcept>
-#include <string>
 
 #include <Kokkos_Core.hpp>
 
@@ -49,19 +47,20 @@ namespace parthenon {
 namespace ErrorChecking {
 
 KOKKOS_INLINE_FUNCTION
-void require(std::string const &condition, std::string const &message,
-             std::string const &filename, int const linenumber) {
+void require(const char * const condition, const char * const message,
+             const char * const filename, int const linenumber) {
   printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
          "%s\n  Line number: %i\n",
-         condition.c_str(), message.c_str(), filename.c_str(), linenumber);
-  exit(EXIT_FAILURE);
+         condition, message, filename, linenumber);
+  Kokkos::abort(message);
 }
 
 KOKKOS_INLINE_FUNCTION
-void fail(std::string const &message, std::string const &filename, int const linenumber) {
+void fail(const char * const message, const char * const filename,
+          int const linenumber) {
   printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-         message.c_str(), filename.c_str(), linenumber);
-  exit(EXIT_FAILURE);
+         message, filename, linenumber);
+  Kokkos::abort(message);
 }
 
 } // namespace ErrorChecking

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -47,8 +47,8 @@ namespace parthenon {
 namespace ErrorChecking {
 
 KOKKOS_INLINE_FUNCTION
-void require(const char * const condition, const char * const message,
-             const char * const filename, int const linenumber) {
+void require(const char *const condition, const char *const message,
+             const char *const filename, int const linenumber) {
   printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
          "%s\n  Line number: %i\n",
          condition, message, filename, linenumber);
@@ -56,8 +56,7 @@ void require(const char * const condition, const char * const message,
 }
 
 KOKKOS_INLINE_FUNCTION
-void fail(const char * const message, const char * const filename,
-          int const linenumber) {
+void fail(const char *const message, const char *const filename, int const linenumber) {
   printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
          message, filename, linenumber);
   Kokkos::abort(message);

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -27,10 +27,15 @@ list(APPEND unit_tests_SOURCES
     test_pararrays.cpp
     test_container_iterator.cpp
     test_required_desired.cpp
+    test_error_checking.cpp
 
 )
 
 add_executable(unit_tests ${unit_tests_SOURCES})
 target_link_libraries(unit_tests PRIVATE parthenon catch2_define Kokkos::kokkos)
+if (TEST_ERROR_CHECKING)
+   message(WARNING "\tTesting error checking. This test will FAIL.")
+   target_compile_definitions(unit_tests PRIVATE PARTHENON_TEST_ERROR_CHECKING)
+endif()
 
 ParseAndAddCatchTests(unit_tests)

--- a/tst/unit/test_error_checking.cpp
+++ b/tst/unit/test_error_checking.cpp
@@ -1,0 +1,45 @@
+//========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2020 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National Nuclear
+// Security Administration. All rights in the program are reserved by Triad
+// National Security, LLC, and the U.S. Department of Energy/National Nuclear
+// Security Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do
+// so.
+//========================================================================================
+
+#include <catch2/catch.hpp>
+
+#include "utils/error_checking.hpp"
+
+#ifdef PARTHENON_TEST_ERROR_CHECKING
+
+TEST_CASE("Parthenon Error Checking","[ErrorChecking][Kokkos]") {
+  SECTION("PARTHENON_REQUIRE passes if condition true") {
+    PARTHENON_REQUIRE(true, "This shouldn't fail");
+  }
+  SECTION("PARTHENON_REQUIRE fails if condition false") {
+    PARTHENON_REQUIRE(false, "This should fail");
+  }
+  SECTION("PARTHENON FAIL causes the code to die") {
+    PARTHENON_FAIL("This should die");
+  }
+  SECTION("PARTHENON_DEBUG_REQUIRE does nothing if NDEBUG is defined") {
+    PARTHENON_DEBUG_REQUIRE(false,
+                            "This should only die if NDEBUG is not defined");
+  }
+  SECTION("PARTHENON_DEBUG_FAIL does nothing if NDEBUG is defined") {
+    PARTHENON_DEBUG_FAIL("This should only die if NDEBUG is not defined");
+  }
+}
+
+#endif // PARTHENON_TEST_ERROR_CHECKING

--- a/tst/unit/test_error_checking.cpp
+++ b/tst/unit/test_error_checking.cpp
@@ -23,19 +23,16 @@
 
 #ifdef PARTHENON_TEST_ERROR_CHECKING
 
-TEST_CASE("Parthenon Error Checking","[ErrorChecking][Kokkos]") {
+TEST_CASE("Parthenon Error Checking", "[ErrorChecking][Kokkos]") {
   SECTION("PARTHENON_REQUIRE passes if condition true") {
     PARTHENON_REQUIRE(true, "This shouldn't fail");
   }
   SECTION("PARTHENON_REQUIRE fails if condition false") {
     PARTHENON_REQUIRE(false, "This should fail");
   }
-  SECTION("PARTHENON FAIL causes the code to die") {
-    PARTHENON_FAIL("This should die");
-  }
+  SECTION("PARTHENON FAIL causes the code to die") { PARTHENON_FAIL("This should die"); }
   SECTION("PARTHENON_DEBUG_REQUIRE does nothing if NDEBUG is defined") {
-    PARTHENON_DEBUG_REQUIRE(false,
-                            "This should only die if NDEBUG is not defined");
+    PARTHENON_DEBUG_REQUIRE(false, "This should only die if NDEBUG is not defined");
   }
   SECTION("PARTHENON_DEBUG_FAIL does nothing if NDEBUG is defined") {
     PARTHENON_DEBUG_FAIL("This should only die if NDEBUG is not defined");

--- a/tst/unit/test_error_checking.cpp
+++ b/tst/unit/test_error_checking.cpp
@@ -21,12 +21,11 @@
 
 #include "utils/error_checking.hpp"
 
-#ifdef PARTHENON_TEST_ERROR_CHECKING
-
 TEST_CASE("Parthenon Error Checking", "[ErrorChecking][Kokkos]") {
   SECTION("PARTHENON_REQUIRE passes if condition true") {
     PARTHENON_REQUIRE(true, "This shouldn't fail");
   }
+#ifdef PARTHENON_TEST_ERROR_CHECKING
   SECTION("PARTHENON_REQUIRE fails if condition false") {
     PARTHENON_REQUIRE(false, "This should fail");
   }
@@ -37,6 +36,5 @@ TEST_CASE("Parthenon Error Checking", "[ErrorChecking][Kokkos]") {
   SECTION("PARTHENON_DEBUG_FAIL does nothing if NDEBUG is defined") {
     PARTHENON_DEBUG_FAIL("This should only die if NDEBUG is not defined");
   }
-}
-
 #endif // PARTHENON_TEST_ERROR_CHECKING
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

As discussed in issue #171 I replace `std::string` and `exit` with `char[]` and `Kokkos::abort`. This functionality should actually work on GPUs and should be performance portable thanks to the `Kokkos::abort` call.

Some things to note:
- I actually use `const char * const`, not `char[]`. I copied this from the implementation of `Kokkos::abort`. I suppose the extra const is more clear but `const char[]` would almost certainly be fine.
- The places in the code calling `PARTHENON_ABORT` and `PARTHENON_REQUIRE` used C++ strings. I had to modify them slightly to pass in a C-style string.
- I added a unit test that tests the error-checking. Kokkos abort, however, obviously kills your program. So the test fails. Therefore, I guard the test in an ifdef. To activate it, configure with `cmake -DTEST_ERROR_CHECKING`. You'll get a warning telling  you your test will fail. And it will.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
