### PR TITLE
Fix string usage in fail message

### DIFF
--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   if (!((profile_str.compare("wave") == 0) ||
         (profile_str.compare("smooth_gaussian") == 0) ||
         (profile_str.compare("hard_sphere") == 0))) {
-    PARTHENON_FAIL("Unknown profile in advection example: " + profile_str);
+    PARTHENON_FAIL(("Unknown profile in advection example: " + profile_str).c_str());
   }
   pkg->AddParam<>("profile", profile_str);
 

--- a/example/advection/redefine_parthenon_defaults.cpp
+++ b/example/advection/redefine_parthenon_defaults.cpp
@@ -181,7 +181,7 @@ void Mesh::UserWorkAfterLoop(ParameterInput *pin, SimTime &tm) {
       if ((pfile = std::freopen(fname.c_str(), "a", pfile)) == nullptr) {
         msg << "### FATAL ERROR in function Mesh::UserWorkAfterLoop" << std::endl
             << "Error output file could not be opened" << std::endl;
-        PARTHENON_FAIL(msg.str());
+        PARTHENON_FAIL(msg.str().c_str());
       }
 
       // The file does not exist -- open the file in write mode and add headers
@@ -189,7 +189,7 @@ void Mesh::UserWorkAfterLoop(ParameterInput *pin, SimTime &tm) {
       if ((pfile = std::fopen(fname.c_str(), "w")) == nullptr) {
         msg << "### FATAL ERROR in function Mesh::UserWorkAfterLoop" << std::endl
             << "Error output file could not be opened" << std::endl;
-        PARTHENON_FAIL(msg.str());
+        PARTHENON_FAIL(msg.str().c_str());
       }
       std::fprintf(pfile, "# Nx1  Nx2  Nx3  Ncycle  ");
       std::fprintf(pfile, "L1 max_error/L1  max_error ");


### PR DESCRIPTION
## PR Summary

Emergency fix as recent merge #172 broke master (#165 introduced new calls to `PARTHENON_FAIL` which were not part of the base of #172 when merging.

## PR Checklist

- [x] Code passes cpplint
- [x] Code is formatted
