### PR TITLE
Ensure that Parthenon build parameters set by host codes are evidently parthenon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,11 +45,7 @@ parthenon-cuda-unit:
 #    - export CUDA_VISIBLE_DEVICES=0
     - mkdir build-cuda-debug
     - cd build-cuda-debug
-    - cmake -DCMAKE_BUILD_TYPE=Debug
-      -DPARTHENON_SINGLE_PRECISION=OFF
-      -DPARTHENON_NGHOST=2
-      -DPARTHENON_DISABLE_HDF5=OFF -DPARTHENON_DISABLE_MPI=OFF -DPARTHENON_DISABLE_OPENMP=OFF 
-      -DHDF5_ROOT=/usr/local/hdf5/parallel
+    - cmake -DCMAKE_BUILD_TYPE=Debug -DHDF5_ROOT=/usr/local/hdf5/parallel
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
       -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
@@ -104,7 +100,7 @@ parthenon-cuda-performance_and_regression:
     - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/serial
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
       -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
-      -DDISABLE_MPI=ON
+      -DPARTHENON_DISABLE_MPI=ON
       -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
       -DKokkos_ENABLE_CUDA_UVM=ON
       ../ && make -j${J} && ctest -L regression -LE mpi-yes --timeout 3600
@@ -156,7 +152,7 @@ parthenon-cpu-performance_and_regression:
     - cd build-perf
     - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/serial
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
-      -DDISABLE_MPI=ON
+      -DPARTHENON_DISABLE_MPI=ON
       ../ && make -j${J} && ctest -L "performance|regression" -LE mpi-yes
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,11 @@ parthenon-cuda-unit:
 #    - export CUDA_VISIBLE_DEVICES=0
     - mkdir build-cuda-debug
     - cd build-cuda-debug
-    - cmake -DCMAKE_BUILD_TYPE=Debug -DHDF5_ROOT=/usr/local/hdf5/parallel
+    - cmake -DCMAKE_BUILD_TYPE=Debug
+      -DPARTHENON_SINGLE_PRECISION=OFF
+      -DPARTHENON_NGHOST=2
+      -DPARTHENON_DISABLE_HDF5=OFF -DPARTHENON_DISABLE_MPI=OFF -DPARTHENON_DISABLE_OPENMP=OFF 
+      -DHDF5_ROOT=/usr/local/hdf5/parallel
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
       -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,10 @@
 cmake_minimum_required(VERSION 3.10)
 project(parthenon LANGUAGES C CXX)
 
-# Options
 include(CTest)
+
+# Options
+option(NUMBER_GHOST_CELLS "Change number of ghost cells" 2)
 option(ENABLE_UNIT_TESTS "Enable unit tests" ${BUILD_TESTING})
 option(ENABLE_INTEGRATION_TESTS "Enable integration tests" ${BUILD_TESTING})
 option(ENABLE_REGRESSION_TESTS "Enable regression tests" ${BUILD_TESTING})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,20 +16,34 @@ project(parthenon LANGUAGES C CXX)
 
 include(CTest)
 
-# Options
-option(NUMBER_GHOST_CELLS "Change number of ghost cells" 2)
+# Compile time constants
+set(PARTHENON_NGHOST 2 CACHE STRING "Number of ghost cells") 
+
+# Compile Options
+option(PARTHENON_SINGLE_PRECISION "Run in single precision" 0) 
+option(PARTHENON_DISABLE_MPI "MPI is enabled by default if found, set this to True to disable MPI" OFF)
+option(PARTHENON_DISABLE_OPENMP "OpenMP is enabled by default if found, set this to True to disable OpenMP" OFF)
+option(PARTHENON_DISABLE_HDF5 "HDF5 is enabled by default if found, set this to True to disable HDF5" OFF)
+
 option(ENABLE_UNIT_TESTS "Enable unit tests" ${BUILD_TESTING})
 option(ENABLE_INTEGRATION_TESTS "Enable integration tests" ${BUILD_TESTING})
 option(ENABLE_REGRESSION_TESTS "Enable regression tests" ${BUILD_TESTING})
-option(DISABLE_MPI "MPI is enabled by default if found, set this to True to disable MPI" OFF)
-option(DISABLE_OPENMP "OpenMP is enabled by default if found, set this to True to disable OpenMP" OFF)
-option(DISABLE_HDF5 "HDF5 is enabled by default if found, set this to True to disable HDF5" OFF)
 option(ENABLE_COMPILER_WARNINGS "Enable compiler warnings" OFF)
 option(CHECK_REGISTRY_PRESSURE "Check the registry pressure for Kokkos CUDA kernels" OFF)
 option(TEST_INTEL_OPTIMIZATION "Test intel optimization and vectorization" OFF)
 option(TEST_ERROR_CHECKING "Enables the error checking unit test. This test will FAIL" OFF)
 
 include(cmake/Format.cmake)
+
+# internal variable for number of ghost cells
+set(NUMBER_GHOST_CELLS ${PARTHENON_NGHOST}) 
+
+# set single precision #define
+if ( PARTHENON_SINGLE_PRECISION )
+  set(SINGLE_PRECISION_ENABLED 1)
+else()
+  set(SINGLE_PRECISION_ENABLED 0)
+endif()  
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -54,21 +68,21 @@ endif()
 
 set(ENABLE_MPI OFF)
 set(NUM_MPI_PROC_TESTING "4" CACHE STRING "Number of mpi processors to use when running tests with MPI")
-if (NOT DISABLE_MPI)
+if (NOT PARTHENON_DISABLE_MPI)
   find_package(MPI COMPONENTS CXX)
   if (NOT MPI_FOUND)
     message(FATAL_ERROR "MPI is required but couldn't be found. "
-    "If you want to build Parthenon without MPI, please rerun CMake with -DDISABLE_MPI=ON")
+    "If you want to build Parthenon without MPI, please rerun CMake with -DPARTHENON_DISABLE_MPI=ON")
   endif()
   set(ENABLE_MPI ON)
 endif()
 
 set(ENABLE_OPENMP OFF)
-if (NOT DISABLE_OPENMP)
+if (NOT PARTHENON_DISABLE_OPENMP)
   find_package(OpenMP COMPONENTS CXX)
   if (NOT OpenMP_FOUND)
     message(FATAL_ERROR "OpenMP is required but couldn't be found. "
-    "If you want to build Parthenon without OpenMP, please rerun CMake with -DDISABLE_OPENMP=ON")
+    "If you want to build Parthenon without OpenMP, please rerun CMake with -DPARTHENON_DISABLE_OPENMP=ON")
   endif()
   set(ENABLE_OPENMP ON)
 endif()
@@ -81,12 +95,12 @@ if (Kokkos_ENABLE_CUDA AND TEST_INTEL_OPTIMIZATION)
 endif()
 
 set(ENABLE_HDF5 OFF)
-if (NOT DISABLE_HDF5)
+if (NOT PARTHENON_DISABLE_HDF5)
   set(HDF5_PREFER_PARALLEL ${ENABLE_MPI})
   find_package(HDF5 COMPONENTS C)
   if (NOT HDF5_FOUND)
     message(FATAL_ERROR "HDF5 is required but couldn't be found. "
-    "If you want to build Parthenon without HDF5, please rerun CMake with -DDISABLE_HDF5=ON")
+    "If you want to build Parthenon without HDF5, please rerun CMake with -DPARTHENON_DISABLE_HDF5=ON")
   endif()
   set(ENABLE_HDF5 ON)
 
@@ -94,7 +108,7 @@ if (NOT DISABLE_HDF5)
     message(FATAL_ERROR "Both MPI and HDF5 are enabled but only a serial version of HDF5 "
     "was found. Please install a parallel version of HDF5 (or point CMake to it by adding its path "
     "to the CMAKE_PREFIX_PATH environment variable), or disable either MPI or HDF5 by rerunning "
-    "CMake with -DDISABLE_MPI=ON or -DDISABLE_HDF5=ON")
+    "CMake with -DPARTHENON_DISABLE_MPI=ON or -DPARTHENON_DISABLE_HDF5=ON")
   endif()
 
   # HDF5 Interface library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ include(CTest)
 set(PARTHENON_NGHOST 2 CACHE STRING "Number of ghost cells") 
 
 # Compile Options
-option(PARTHENON_SINGLE_PRECISION "Run in single precision" 0) 
+option(PARTHENON_SINGLE_PRECISION "Run in single precision" OFF) 
 option(PARTHENON_DISABLE_MPI "MPI is enabled by default if found, set this to True to disable MPI" OFF)
 option(PARTHENON_DISABLE_OPENMP "OpenMP is enabled by default if found, set this to True to disable OpenMP" OFF)
 option(PARTHENON_DISABLE_HDF5 "HDF5 is enabled by default if found, set this to True to disable HDF5" OFF)

--- a/docs/building.md
+++ b/docs/building.md
@@ -24,7 +24,7 @@ ctest -LE performance
 ctest -L performance
 ```
 
-## List of cmake options:
+### List of cmake options:
 
    |         Option           | Default | Type   | Description |
    | -----------------------: | :------ | :----- | :---------- |
@@ -33,11 +33,12 @@ ctest -L performance
    |    PARTHENON_DISABLE_MPI | OFF     | Option | MPI is enabled by default if found, set this to True to disable MPI |
    | PARTHENON_DISABLE_OPENMP | OFF     | Option | OpenMP is enabled by default if found, set this to True to disable OpenMP |
    | ENABLE_COMPILER_WARNINGS | OFF     | Option | Enable compiler warnings |
-   |            BUILD_TESTING | ON      | Option | Multi-testing enablement |
    |      TEST_ERROR_CHECKING | OFF     | Option | Enables the error checking unit test. This test will FAIL |
    |  TEST_INTEL_OPTIMIZATION | OFF     | Option | Test intel optimization and vectorization |
    |  CHECK_REGISTRY_PRESSURE | OFF     | Option | Check the registry pressure for Kokkos CUDA kernels |
+   |            BUILD_TESTING | ON      | Option | Multi-testing enablement |
    | ENABLE_INTEGRATION_TESTS | ${BUILD_TESTING} | Option | Enable integration tests |
    |  ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
    |        ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
 
+   Note: Options that are prefixed with PARTHENON_ modify behavior.

--- a/docs/building.md
+++ b/docs/building.md
@@ -42,4 +42,4 @@ ctest -L performance
    |    ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
    |          ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
 
-### NB: CMake pptions prefixed with *PARTHENON_* modify behavior.
+### NB: CMake options prefixed with *PARTHENON_* modify behavior.

--- a/docs/building.md
+++ b/docs/building.md
@@ -26,20 +26,20 @@ ctest -L performance
 
 ### List of cmake options:
 
-   |           Option           | Default | Type   | Description |
-   | -------------------------: | :------ | :----- | :---------- |
-   |           PARTHENON_NGHOST | 2       | String | Number of ghost cells | 
-   | PARTHENON_SINGLE_PRECISION | OFF     | Option | Enable single precision mode if requested |
-   |     PARTHENON_DISABLE_HDF5 | OFF     | Option | HDF5 is enabled by default if found, set this to True to disable HDF5 |
-   |      PARTHENON_DISABLE_MPI | OFF     | Option | MPI is enabled by default if found, set this to True to disable MPI |
-   |   PARTHENON_DISABLE_OPENMP | OFF     | Option | OpenMP is enabled by default if found, set this to True to disable OpenMP |
-   |   ENABLE_COMPILER_WARNINGS | OFF     | Option | Enable compiler warnings |
-   |        TEST_ERROR_CHECKING | OFF     | Option | Enables the error checking unit test. This test will FAIL |
-   |    TEST_INTEL_OPTIMIZATION | OFF     | Option | Test intel optimization and vectorization |
-   |    CHECK_REGISTRY_PRESSURE | OFF     | Option | Check the registry pressure for Kokkos CUDA kernels |
-   |              BUILD_TESTING | ON      | Option | Multi-testing enablement |
-   |   ENABLE_INTEGRATION_TESTS | ${BUILD_TESTING} | Option | Enable integration tests |
-   |    ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
-   |          ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
+   |           Option             | Default  | Type   | Description |
+   | ---------------------------: | :------- | :----- | :---------- |
+   |            PARTHENON\_NGHOST | 2        | String | Number of ghost cells | 
+   | PARTHENON\_SINGLE\_PRECISION | OFF      | Option | Enable single precision mode if requested |
+   |     PARTHENON\_DISABLE\_HDF5 | OFF      | Option | HDF5 is enabled by default if found, set this to True to disable HDF5 |
+   |      PARTHENON\_DISABLE\_MPI | OFF      | Option | MPI is enabled by default if found, set this to True to disable MPI |
+   |   PARTHENON\_DISABLE\_OPENMP | OFF      | Option | OpenMP is enabled by default if found, set this to True to disable OpenMP |
+   |   ENABLE\_COMPILER\_WARNINGS | OFF      | Option | Enable compiler warnings |
+   |        TEST\_ERROR\_CHECKING | OFF      | Option | Enables the error checking unit test. This test will FAIL |
+   |    TEST\_INTEL\_OPTIMIZATION | OFF      | Option | Test intel optimization and vectorization |
+   |    CHECK\_REGISTRY\_PRESSURE | OFF      | Option | Check the registry pressure for Kokkos CUDA kernels |
+   |               BUILD\_TESTING | ON       | Option | Multi-testing enablement |
+   |   ENABLE\_INTEGRATION\_TESTS | ${BUILD\_TESTING} | Option | Enable integration tests |
+   |    ENABLE\_REGRESSION\_TESTS | ${BUILD\_TESTING} | Option | Enable regression tests |
+   |          ENABLE\_UNIT\_TESTS | ${BUILD\_TESTING} | Option | Enable unit tests |
 
-### NB: CMake options prefixed with *PARTHENON_* modify behavior.
+### NB: CMake options prefixed with *PARTHENON\_* modify behavior.

--- a/docs/building.md
+++ b/docs/building.md
@@ -26,19 +26,20 @@ ctest -L performance
 
 ### List of cmake options:
 
-   |         Option           | Default | Type   | Description |
-   | -----------------------: | :------ | :----- | :---------- |
-   |         PARTHENON_NGHOST | 2       | String | Number of ghost cells | 
-   |   PARTHENON_DISABLE_HDF5 | OFF     | Option | HDF5 is enabled by default if found, set this to True to disable HDF5 |
-   |    PARTHENON_DISABLE_MPI | OFF     | Option | MPI is enabled by default if found, set this to True to disable MPI |
-   | PARTHENON_DISABLE_OPENMP | OFF     | Option | OpenMP is enabled by default if found, set this to True to disable OpenMP |
-   | ENABLE_COMPILER_WARNINGS | OFF     | Option | Enable compiler warnings |
-   |      TEST_ERROR_CHECKING | OFF     | Option | Enables the error checking unit test. This test will FAIL |
-   |  TEST_INTEL_OPTIMIZATION | OFF     | Option | Test intel optimization and vectorization |
-   |  CHECK_REGISTRY_PRESSURE | OFF     | Option | Check the registry pressure for Kokkos CUDA kernels |
-   |            BUILD_TESTING | ON      | Option | Multi-testing enablement |
-   | ENABLE_INTEGRATION_TESTS | ${BUILD_TESTING} | Option | Enable integration tests |
-   |  ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
-   |        ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
+   |           Option           | Default | Type   | Description |
+   | -------------------------: | :------ | :----- | :---------- |
+   |           PARTHENON_NGHOST | 2       | String | Number of ghost cells | 
+   | PARTHENON_SINGLE_PRECISION | OFF     | Option | Enable single precision mode if requested |
+   |     PARTHENON_DISABLE_HDF5 | OFF     | Option | HDF5 is enabled by default if found, set this to True to disable HDF5 |
+   |      PARTHENON_DISABLE_MPI | OFF     | Option | MPI is enabled by default if found, set this to True to disable MPI |
+   |   PARTHENON_DISABLE_OPENMP | OFF     | Option | OpenMP is enabled by default if found, set this to True to disable OpenMP |
+   |   ENABLE_COMPILER_WARNINGS | OFF     | Option | Enable compiler warnings |
+   |        TEST_ERROR_CHECKING | OFF     | Option | Enables the error checking unit test. This test will FAIL |
+   |    TEST_INTEL_OPTIMIZATION | OFF     | Option | Test intel optimization and vectorization |
+   |    CHECK_REGISTRY_PRESSURE | OFF     | Option | Check the registry pressure for Kokkos CUDA kernels |
+   |              BUILD_TESTING | ON      | Option | Multi-testing enablement |
+   |   ENABLE_INTEGRATION_TESTS | ${BUILD_TESTING} | Option | Enable integration tests |
+   |    ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
+   |          ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
 
    Note: Options that are prefixed with PARTHENON_ modify behavior.

--- a/docs/building.md
+++ b/docs/building.md
@@ -42,4 +42,4 @@ ctest -L performance
    |    ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
    |          ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
 
-   Note: Options that are prefixed with PARTHENON_ modify behavior.
+### NB: CMake pptions prefixed with *PARTHENON_* modify behavior.

--- a/docs/building.md
+++ b/docs/building.md
@@ -23,3 +23,21 @@ ctest -LE performance
 # run performance tests
 ctest -L performance
 ```
+
+## List of cmake options:
+
+   |         Option           | Default | Type   | Description |
+   | -----------------------: | :------ | :----- | :---------- |
+   |         PARTHENON_NGHOST | 2       | String | Number of ghost cells | 
+   |   PARTHENON_DISABLE_HDF5 | OFF     | Option | HDF5 is enabled by default if found, set this to True to disable HDF5 |
+   |    PARTHENON_DISABLE_MPI | OFF     | Option | MPI is enabled by default if found, set this to True to disable MPI |
+   | PARTHENON_DISABLE_OPENMP | OFF     | Option | OpenMP is enabled by default if found, set this to True to disable OpenMP |
+   | ENABLE_COMPILER_WARNINGS | OFF     | Option | Enable compiler warnings |
+   |            BUILD_TESTING | ON      | Option | Multi-testing enablement |
+   |      TEST_ERROR_CHECKING | OFF     | Option | Enables the error checking unit test. This test will FAIL |
+   |  TEST_INTEL_OPTIMIZATION | OFF     | Option | Test intel optimization and vectorization |
+   |  CHECK_REGISTRY_PRESSURE | OFF     | Option | Check the registry pressure for Kokkos CUDA kernels |
+   | ENABLE_INTEGRATION_TESTS | ${BUILD_TESTING} | Option | Enable integration tests |
+   |  ENABLE_REGRESSION_TESTS | ${BUILD_TESTING} | Option | Enable regression tests |
+   |        ENABLE_UNIT_TESTS | ${BUILD_TESTING} | Option | Enable unit tests |
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 # Configure defs.hpp
 set(PROBLEM_GENERATOR "<not-implemented>") # TODO: Figure out what to put here
-set(SINGLE_PRECISION_ENABLED 0) # TODO: Add CMake option for this
 
 if (ENABLE_MPI)
   set(MPI_OPTION MPI_PARALLEL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,6 @@ set(COMPILER_FLAGS "<not-implemented>") # TODO: Put something more descriptive h
 
 set(NFIELD_VARIABLES 0) # TODO: Remove
 set(NWAVE_VALUE 5) # TODO: Remove
-set(NUMBER_GHOST_CELLS 2) # TODO: Make this a CMake option and check it
 set(COORDINATE_TYPE UniformCartesian) # TODO: Make this an option when more are available
 
 configure_file(defs.hpp.in generated/defs.hpp @ONLY)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Exposed Parthenon build parameters that host codes might want to modify.  These were also prefixed by a PARTHENON_ .  These include:

1. PARTHENON_DISABLE_MPI
1. PARTHENON_DISABLE_HDF5
1. PARTHENON_DISABLE_OPENMP
1. PARTHENON_NGHOST
1. PARTHENON_SINGLE_PRECISION

## PR Checklist
- [x] Code is formatted
- [x] Changes are documented
