### PR TITLE
Use host side labels

### DIFF
--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -157,12 +157,12 @@ TaskList AdvectionDriver::MakeTaskList(MeshBlock *pmb, int stage) {
     // need to purge the stages and recreate the non-base containers or else there will be
     // bugs, e.g. the containers for rk stages won't have the same variables as the "base"
     // container, likely leading to strange errors and/or segfaults.
-    auto purge_stages = tl.AddTask<BlockTask>(
-        [](MeshBlock *pmb) {
-          pmb->real_containers.PurgeNonBase();
-          return TaskStatus::complete;
-        },
-        fill_derived, pmb);
+    //auto purge_stages = tl.AddTask<BlockTask>(
+    //    [](MeshBlock *pmb) {
+    //      pmb->real_containers.PurgeNonBase();
+    //      return TaskStatus::complete;
+    //    },
+    //    fill_derived, pmb);
   }
   return tl;
 }

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -151,18 +151,6 @@ TaskList AdvectionDriver::MakeTaskList(MeshBlock *pmb, int stage) {
           },
           fill_derived, pmb);
     }
-    // Purge stages -- this task isn't really required.  If we don't purge the containers
-    // then the next time we go to add them, they'll already exist and it will be a no-op.
-    // Not purging the stages is more performant, but if the "base" Container changes, we
-    // need to purge the stages and recreate the non-base containers or else there will be
-    // bugs, e.g. the containers for rk stages won't have the same variables as the "base"
-    // container, likely leading to strange errors and/or segfaults.
-    //auto purge_stages = tl.AddTask<BlockTask>(
-    //    [](MeshBlock *pmb) {
-    //      pmb->real_containers.PurgeNonBase();
-    //      return TaskStatus::complete;
-    //    },
-    //    fill_derived, pmb);
   }
   return tl;
 }

--- a/example/advection/advection_driver.hpp
+++ b/example/advection/advection_driver.hpp
@@ -41,27 +41,27 @@ class AdvectionDriver : public MultiStageBlockTaskDriver {
 using ContainerTaskFunc = std::function<TaskStatus(Container<Real> &)>;
 class ContainerTask : public BaseTask {
  public:
-  ContainerTask(TaskID id, ContainerTaskFunc func, TaskID dep, Container<Real> rc)
-      : BaseTask(id, dep), _func(func), _cont(rc) {}
-  TaskStatus operator()() { return _func(_cont); }
+  ContainerTask(TaskID id, ContainerTaskFunc func, TaskID dep, Container<Real> &rc)
+      : BaseTask(id, dep), _func(func), _cont(&rc) {}
+  TaskStatus operator()() { return _func(*_cont); }
 
  private:
   ContainerTaskFunc _func;
-  Container<Real> _cont;
+  Container<Real> *_cont;
 };
 using TwoContainerTaskFunc =
     std::function<TaskStatus(Container<Real> &, Container<Real> &)>;
 class TwoContainerTask : public BaseTask {
  public:
-  TwoContainerTask(TaskID id, TwoContainerTaskFunc func, TaskID dep, Container<Real> rc1,
-                   Container<Real> rc2)
-      : BaseTask(id, dep), _func(func), _cont1(rc1), _cont2(rc2) {}
-  TaskStatus operator()() { return _func(_cont1, _cont2); }
+  TwoContainerTask(TaskID id, TwoContainerTaskFunc func, TaskID dep, Container<Real> &rc1,
+                   Container<Real> &rc2)
+      : BaseTask(id, dep), _func(func), _cont1(&rc1), _cont2(&rc2) {}
+  TaskStatus operator()() { return _func(*_cont1, *_cont2); }
 
  private:
   TwoContainerTaskFunc _func;
-  Container<Real> _cont1;
-  Container<Real> _cont2;
+  Container<Real> *_cont1;
+  Container<Real> *_cont2;
 };
 
 } // namespace advection_example

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -50,7 +50,7 @@ class CellVariable {
   CellVariable<T>(const std::string label, const std::array<int, 6> dims,
                   const Metadata &metadata)
       : data(label, dims[5], dims[4], dims[3], dims[2], dims[1], dims[0]),
-        mpiStatus(false), m_(metadata) {}
+        mpiStatus(false), m_(metadata), label_(label) {}
 
   // make a new CellVariable based on an existing one
   std::shared_ptr<CellVariable<T>> AllocateCopy(const bool allocComms = false,
@@ -67,7 +67,7 @@ class CellVariable {
   auto GetDim(const int i) const { return data.GetDim(i); }
 
   ///< retrieve label for variable
-  const std::string label() const { return data.label(); }
+  const std::string label() const { return label_; }
 
   ///< retrieve metadata for variable
   Metadata metadata() const { return m_; }
@@ -94,6 +94,7 @@ class CellVariable {
 
  private:
   Metadata m_;
+  std::string label_;
 };
 
 ///

--- a/src/task_list/tasks.hpp
+++ b/src/task_list/tasks.hpp
@@ -196,7 +196,7 @@ class TaskList {
     return TaskListStatus::running;
   }
   template <typename T, class... Args>
-  TaskID AddTask(Args... args) {
+  TaskID AddTask(Args&&... args) {
     TaskID id(tasks_added_ + 1);
     task_list_.push_back(std::make_unique<T>(id, std::forward<Args>(args)...));
     tasks_added_++;

--- a/src/task_list/tasks.hpp
+++ b/src/task_list/tasks.hpp
@@ -196,7 +196,7 @@ class TaskList {
     return TaskListStatus::running;
   }
   template <typename T, class... Args>
-  TaskID AddTask(Args&&... args) {
+  TaskID AddTask(Args &&... args) {
     TaskID id(tasks_added_ + 1);
     task_list_.push_back(std::make_unique<T>(id, std::forward<Args>(args)...));
     tasks_added_++;


### PR DESCRIPTION

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a trivial change that restores the label field host side for the CellVariable class.  This should avoid the need to make deep copies from the device.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

May help address concerns raised in #189.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] Code is formatted
