### PR TITLE
Removed PI and TWO_PI from defs.hpp.in

### DIFF
--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -116,7 +116,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   if (ang_2_vert) lambda = x3;
 
   // Initialize k_parallel
-  Real k_par = 2.0 * (PI) / lambda;
+  Real k_par = 2.0 * (M_PI) / lambda;
 
   pkg->AddParam<>("amp", amp);
   pkg->AddParam<>("vel", vel);

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -73,8 +73,6 @@
 // general purpose macros (never modified)
 
 // all constants specified to 17 total digits of precision = max_digits10 for "double"
-#define PI 3.1415926535897932
-#define TWO_PI 6.2831853071795862
 #define SQRT2 1.4142135623730951
 #define ONE_OVER_SQRT2 0.70710678118654752
 #define ONE_3RD 0.33333333333333333


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Replaced local definition of PI with M_PI.

<!--Please provide at least 1-2 sentences describing the pull request in
Allows us to use other third party libraries that define pi without a namespace.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] N/A New features are documented.
- [x] N/A Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
