### PR TITLE
Allow non-static class member functions to be tasks

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -8,6 +8,8 @@ The `TaskList` class implements methods to build and execute a set of tasks with
 
 When adding functions that are non-static class member functions, a slightly different interface is required.  The first argument should be the class-name-scoped name of the function.  For example, for a function named `DoSomething` in class `SomeClass`, the first argument would be `&SomeClass::DoSomething`.  The second argument should be a pointer to the object that should invoke this member function.  Finally, the dependencies and function arguments should be provided as described above.
 
+Examples of both `AddTask` calls can be found in the advection example [here](../examples/advection/advection_driver.cpp).
+
 ### DoAvailable
 `DoAvailable` loops over the task list once, executing all tasks whose dependencies are satisfied.  The function returns either `TaskListStatus::complete` if all tasks have been executed (and the task list is therefore empty) or `TaskListStatus::running` if tasks remain to be completed.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -6,6 +6,8 @@ The `TaskList` class implements methods to build and execute a set of tasks with
 ### AddTask
 `AddTask` is a templated variadic function that takes the task function to be executed, the task dependencies (see `TaskID` below), and the arguments to the task function as it's arguments.  All arguments are captured by value in a lambda for later execution.
 
+When adding functions that are non-static class member functions, a slightly different interface is required.  The first argument should be the class-name-scoped name of the function.  For example, for a function named `DoSomething` in class `SomeClass`, the first argument would be `&SomeClass::DoSomething`.  The second argument should be a pointer to the object that should invoke this member function.  Finally, the dependencies and function arguments should be provided as described above.
+
 ### DoAvailable
 `DoAvailable` loops over the task list once, executing all tasks whose dependencies are satisfied.  The function returns either `TaskListStatus::complete` if all tasks have been executed (and the task list is therefore empty) or `TaskListStatus::running` if tasks remain to be completed.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -8,7 +8,7 @@ The `TaskList` class implements methods to build and execute a set of tasks with
 
 When adding functions that are non-static class member functions, a slightly different interface is required.  The first argument should be the class-name-scoped name of the function.  For example, for a function named `DoSomething` in class `SomeClass`, the first argument would be `&SomeClass::DoSomething`.  The second argument should be a pointer to the object that should invoke this member function.  Finally, the dependencies and function arguments should be provided as described above.
 
-Examples of both `AddTask` calls can be found in the advection example [here](../examples/advection/advection_driver.cpp).
+Examples of both `AddTask` calls can be found in the advection example [here](../example/advection/advection_driver.cpp).
 
 ### DoAvailable
 `DoAvailable` loops over the task list once, executing all tasks whose dependencies are satisfied.  The function returns either `TaskListStatus::complete` if all tasks have been executed (and the task list is therefore empty) or `TaskListStatus::running` if tasks remain to be completed.

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -449,7 +449,7 @@ void Container<T>::Remove(const std::string label) {
 }
 
 template <typename T>
-void Container<T>::SendFluxCorrection() {
+TaskStatus Container<T>::SendFluxCorrection() {
   for (auto &v : varVector_) {
     if (v->IsSet(Metadata::Independent)) {
       v->vbvar->SendFluxCorrection();
@@ -463,10 +463,11 @@ void Container<T>::SendFluxCorrection() {
       }
     }
   }
+  return TaskStatus::complete;
 }
 
 template <typename T>
-bool Container<T>::ReceiveFluxCorrection() {
+TaskStatus Container<T>::ReceiveFluxCorrection() {
   int success = 0, total = 0;
   for (auto &v : varVector_) {
     if (v->IsSet(Metadata::Independent)) {
@@ -483,11 +484,12 @@ bool Container<T>::ReceiveFluxCorrection() {
       }
     }
   }
-  return (success == total);
+  if (success == total) return TaskStatus::complete;
+  return TaskStatus::incomplete;
 }
 
 template <typename T>
-void Container<T>::SendBoundaryBuffers() {
+TaskStatus Container<T>::SendBoundaryBuffers() {
   // sends the boundary
   debug = 0;
   //  std::cout << "_________SEND from stage:"<<s->name()<<std::endl;
@@ -507,7 +509,7 @@ void Container<T>::SendBoundaryBuffers() {
     }
   }
 
-  return;
+  return TaskStatus::complete;
 }
 
 template <typename T>
@@ -532,7 +534,7 @@ void Container<T>::SetupPersistentMPI() {
 }
 
 template <typename T>
-bool Container<T>::ReceiveBoundaryBuffers() {
+TaskStatus Container<T>::ReceiveBoundaryBuffers() {
   bool ret;
   //  std::cout << "_________RECV from stage:"<<s->name()<<std::endl;
   ret = true;
@@ -563,11 +565,12 @@ bool Container<T>::ReceiveBoundaryBuffers() {
     }
   }
 
-  return ret;
+  if (ret) return TaskStatus::complete;
+  return TaskStatus::incomplete;
 }
 
 template <typename T>
-void Container<T>::ReceiveAndSetBoundariesWithWait() {
+TaskStatus Container<T>::ReceiveAndSetBoundariesWithWait() {
   //  std::cout << "_________RSET from stage:"<<s->name()<<std::endl;
   for (auto &v : varVector_) {
     if ((!v->mpiStatus) && v->IsSet(Metadata::FillGhost)) {
@@ -588,13 +591,14 @@ void Container<T>::ReceiveAndSetBoundariesWithWait() {
       }
     }
   }
+  return TaskStatus::complete;
 }
 // This really belongs in Container.cpp. However if I put it in there,
 // the meshblock file refuses to compile.  Don't know what's going on
 // there, but for now this is the workaround at the expense of code
 // bloat.
 template <typename T>
-void Container<T>::SetBoundaries() {
+TaskStatus Container<T>::SetBoundaries() {
   //    std::cout << "in set" << std::endl;
   // sets the boundary
   //  std::cout << "_________BSET from stage:"<<s->name()<<std::endl;
@@ -613,6 +617,7 @@ void Container<T>::SetBoundaries() {
       }
     }
   }
+  return TaskStatus::complete;
 }
 
 template <typename T>
@@ -633,7 +638,7 @@ void Container<T>::ResetBoundaryCellVariables() {
 }
 
 template <typename T>
-void Container<T>::StartReceiving(BoundaryCommSubset phase) {
+TaskStatus Container<T>::StartReceiving(BoundaryCommSubset phase) {
   //    std::cout << "in set" << std::endl;
   // sets the boundary
   //  std::cout << "________CLEAR from stage:"<<s->name()<<std::endl;
@@ -654,10 +659,11 @@ void Container<T>::StartReceiving(BoundaryCommSubset phase) {
       }
     }
   }
+  return TaskStatus::complete;
 }
 
 template <typename T>
-void Container<T>::ClearBoundary(BoundaryCommSubset phase) {
+TaskStatus Container<T>::ClearBoundary(BoundaryCommSubset phase) {
   //    std::cout << "in set" << std::endl;
   // sets the boundary
   //  std::cout << "________CLEAR from stage:"<<s->name()<<std::endl;
@@ -674,6 +680,7 @@ void Container<T>::ClearBoundary(BoundaryCommSubset phase) {
       }
     }
   }
+  return TaskStatus::complete;
 }
 
 template <typename T>

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -267,42 +267,14 @@ class Container {
   // Communication routines
   void ResetBoundaryCellVariables();
   void SetupPersistentMPI();
-  void SetBoundaries();
-  void SendBoundaryBuffers();
-  void ReceiveAndSetBoundariesWithWait();
-  bool ReceiveBoundaryBuffers();
-  void StartReceiving(BoundaryCommSubset phase);
-  void ClearBoundary(BoundaryCommSubset phase);
-  void SendFluxCorrection();
-  bool ReceiveFluxCorrection();
-  static TaskStatus StartReceivingTask(std::shared_ptr<Container<T>> rc) {
-    rc->StartReceiving(BoundaryCommSubset::all);
-    return TaskStatus::complete;
-  }
-  static TaskStatus SendFluxCorrectionTask(std::shared_ptr<Container<T>> rc) {
-    rc->SendFluxCorrection();
-    return TaskStatus::complete;
-  }
-  static TaskStatus ReceiveFluxCorrectionTask(std::shared_ptr<Container<T>> rc) {
-    if (!rc->ReceiveFluxCorrection()) return TaskStatus::incomplete;
-    return TaskStatus::complete;
-  }
-  static TaskStatus SendBoundaryBuffersTask(std::shared_ptr<Container<T>> rc) {
-    rc->SendBoundaryBuffers();
-    return TaskStatus::complete;
-  }
-  static TaskStatus ReceiveBoundaryBuffersTask(std::shared_ptr<Container<T>> rc) {
-    if (!rc->ReceiveBoundaryBuffers()) return TaskStatus::incomplete;
-    return TaskStatus::complete;
-  }
-  static TaskStatus SetBoundariesTask(std::shared_ptr<Container<T>> rc) {
-    rc->SetBoundaries();
-    return TaskStatus::complete;
-  }
-  static TaskStatus ClearBoundaryTask(std::shared_ptr<Container<T>> rc) {
-    rc->ClearBoundary(BoundaryCommSubset::all);
-    return TaskStatus::complete;
-  }
+  TaskStatus SetBoundaries();
+  TaskStatus SendBoundaryBuffers();
+  TaskStatus ReceiveAndSetBoundariesWithWait();
+  TaskStatus ReceiveBoundaryBuffers();
+  TaskStatus StartReceiving(BoundaryCommSubset phase);
+  TaskStatus ClearBoundary(BoundaryCommSubset phase);
+  TaskStatus SendFluxCorrection();
+  TaskStatus ReceiveFluxCorrection();
 
   bool operator==(const Container<T> &cmp) {
     // do some kind of check of equality

--- a/src/parthenon/prelude.hpp
+++ b/src/parthenon/prelude.hpp
@@ -16,6 +16,7 @@
 
 // Internal Includes
 #include <basic_types.hpp>
+#include <defs.hpp>
 #include <globals.hpp>
 #include <interface/container.hpp>
 #include <interface/variable.hpp>
@@ -27,6 +28,7 @@
 
 namespace parthenon {
 namespace prelude {
+using ::parthenon::BoundaryCommSubset;
 using ::parthenon::CellVariable;
 using ::parthenon::Container;
 using ::parthenon::IndexDomain;

--- a/src/tasks/task_list.hpp
+++ b/src/tasks/task_list.hpp
@@ -93,6 +93,17 @@ class TaskList {
     return id;
   }
 
+  // overload to add member functions of class T to task list
+  // NOTE: we must capture the object pointer
+  template <class F, class T, class... Args>
+  TaskID AddTask(F func, T *obj, TaskID &dep, Args &&... args) {
+    TaskID id(tasks_added_ + 1);
+    task_list_.push_back(
+        Task(id, dep, [=]() mutable -> TaskStatus { return (obj->*func)(args...); }));
+    tasks_added_++;
+    return id;
+  }
+
   void Print() {
     int i = 0;
     std::cout << "TaskList::Print():" << std::endl;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR adds an overload of the AddTask function that enables app developers to add non-static class member functions to task lists.  The interface is necessarily slightly different because non-static member functions need to be invoked by an object of the class, which in turn needs to be captured by the lambda we use to represent tasks.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Addresses #231 

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
