### PR TITLE
Correct CMAKE variable, make local to project

### DIFF
--- a/cmake/CodeCov.cmake
+++ b/cmake/CodeCov.cmake
@@ -40,15 +40,15 @@ if(CODE_COVERAGE)
     COMMAND mkdir -p ${COVERAGE_PATH}/${COVERAGE_NAME}
     COMMAND ${PATH_LCOV} --version
     # Clean
-    COMMAND ${PATH_LCOV} --gcov-tool ${PATH_GCOV} --directory ${CMAKE_BINARY_DIR} -b ${CMAKE_SOURCE_DIR} --zerocounters
+    COMMAND ${PATH_LCOV} --gcov-tool ${PATH_GCOV} --directory ${PROJECT_BINARY_DIR} -b ${PROJECT_SOURCE_DIR} --zerocounters
     # Base report
     COMMAND ctest -L coverage --verbose
-    COMMAND ${PATH_LCOV} --gcov-tool ${PATH_GCOV} -c -i -d ${CMAKE_BINARY_DIR} -b ${CMAKE_SOURCE_DIR} -o ${COVERAGE_PATH}/${COVERAGE_NAME}/report.base.old
+    COMMAND ${PATH_LCOV} --gcov-tool ${PATH_GCOV} -c -i -d ${PROJECT_BINARY_DIR} -b ${PROJECT_SOURCE_DIR} -o ${COVERAGE_PATH}/${COVERAGE_NAME}/report.base.old
     # Remove Kokkos and tst info from code coverage
     COMMAND ${PATH_LCOV} --remove ${COVERAGE_PATH}/${COVERAGE_NAME}/report.base.old "*/Kokkos/*" "*/tst/*" -o ${COVERAGE_PATH}/${COVERAGE_NAME}/report.base
 
     # Capture information from test runs
-    COMMAND ${PATH_LCOV} --gcov-tool ${PATH_GCOV} --directory ${CMAKE_BINARY_DIR} -b ${CMAKE_SOURCE_DIR} --capture --output-file ${COVERAGE_PATH}/${COVERAGE_NAME}/report.test.old
+    COMMAND ${PATH_LCOV} --gcov-tool ${PATH_GCOV} --directory ${PROJECT_BINARY_DIR} -b ${PROJECT_SOURCE_DIR} --capture --output-file ${COVERAGE_PATH}/${COVERAGE_NAME}/report.test.old
     # Remove Kokkos and tst info from code coverage
     COMMAND ${PATH_LCOV} --remove ${COVERAGE_PATH}/${COVERAGE_NAME}/report.test.old "*/Kokkos/*" "*/tst/*" -o ${COVERAGE_PATH}/${COVERAGE_NAME}/report.test
     
@@ -59,7 +59,7 @@ if(CODE_COVERAGE)
     COMMAND rm ${COVERAGE_PATH}/${COVERAGE_NAME}/report.base.old
     COMMAND rm ${COVERAGE_PATH}/${COVERAGE_NAME}/report.base
     COMMAND rm ${COVERAGE_PATH}/${COVERAGE_NAME}/report.test
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     )
 
   set(UPLOAD_COMMAND "bash <\(curl -s https://codecov.io/bash\) \|\| echo \"code coverage failed to upload\"")
@@ -67,10 +67,10 @@ if(CODE_COVERAGE)
   add_custom_command(TARGET coverage-upload
     COMMAND echo "================ Uploading Code Coverage =================="
     # Upload coverage report
-    COMMAND ${CMAKE_SOURCE_DIR}/scripts/combine_coverage.sh ${PATH_LCOV} ${PATH_GCOV} ${COVERAGE_PATH}
+    COMMAND ${PROJECT_SOURCE_DIR}/scripts/combine_coverage.sh ${PATH_LCOV} ${PATH_GCOV} ${COVERAGE_PATH}
     COMMAND curl -s https://codecov.io/bash > ${COVERAGE_PATH}/CombinedCoverage/script.coverage
     COMMAND cat ${COVERAGE_PATH}/CombinedCoverage/script.coverage
-    COMMAND cd ${COVERAGE_PATH}/CombinedCoverage && bash ${COVERAGE_PATH}/CombinedCoverage/script.coverage -p ${CMAKE_BINARY_DIR} -s ${COVERAGE_PATH}/CombinedCoverage
+    COMMAND cd ${COVERAGE_PATH}/CombinedCoverage && bash ${COVERAGE_PATH}/CombinedCoverage/script.coverage -p ${PROJECT_BINARY_DIR} -s ${COVERAGE_PATH}/CombinedCoverage
     WORKING_DIRECTORY ${COVERAGE_PATH}
     )
 

--- a/cmake/CodeCov.cmake
+++ b/cmake/CodeCov.cmake
@@ -30,7 +30,6 @@ if(CODE_COVERAGE)
 
   message(STATUS "Coverage reports will be placed in ${COVERAGE_PATH}/${COVERAGE_NAME}")
  
-  set(OBJECT_DIR ${CMAKE_BINARY_DIR}/obj)
   get_target_property(PARTHENON_SOURCES parthenon SOURCES)
   get_target_property(UNIT_TEST_SOURCES unit_tests SOURCES)
 

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -33,7 +33,7 @@ function(setup_test dir arg)
   separate_arguments(arg) 
   add_test( NAME regression_test:${dir} COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/run_test.py" 
     ${arg} --test_dir "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}"
-    --output_dir "${CMAKE_BINARY_DIR}/tst/regression/outputs/${dir}")
+    --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}")
   set_tests_properties(regression_test:${dir} PROPERTIES LABELS "regression;mpi-no" )
   record_driver("${arg}")
 endfunction()
@@ -47,7 +47,7 @@ function(setup_test_coverage dir arg)
     ${arg} 
     --coverage
     --test_dir "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}"
-    --output_dir "${CMAKE_BINARY_DIR}/tst/regression/outputs/${dir}_cov")
+    --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}_cov")
   set_tests_properties(regression_coverage_test:${dir} PROPERTIES LABELS "regression;coverage;mpi-no" )
   record_driver("${arg}")
 endfunction()
@@ -63,7 +63,7 @@ function(setup_test_mpi nproc dir arg)
       --mpirun_opts=${MPIEXEC_NUMPROC_FLAG} --mpirun_opts=${nproc}
       --mpirun_opts=${MPIEXEC_PREFLAGS} ${arg}
       --test_dir ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}
-      --output_dir "${CMAKE_BINARY_DIR}/tst/regression/outputs/${dir}_mpi")
+      --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}_mpi")
     set_tests_properties(regression_mpi_test:${dir} PROPERTIES LABELS "regression;mpi-yes" RUN_SERIAL ON )
     record_driver("${arg}")
   else()
@@ -83,7 +83,7 @@ function(setup_test_mpi_coverage nproc dir arg)
       --mpirun_opts=${MPIEXEC_NUMPROC_FLAG} --mpirun_opts=${nproc}
       --mpirun_opts=${MPIEXEC_PREFLAGS} ${arg}
       --test_dir ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}
-      --output_dir "${CMAKE_BINARY_DIR}/tst/regression/outputs/${dir}_mpi_cov"
+      --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}_mpi_cov"
       )
     set_tests_properties(regression_mpi_coverage_test:${dir} PROPERTIES LABELS "regression;coverage;mpi-yes" RUN_SERIAL ON )
   else()

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -12,7 +12,7 @@
 #=========================================================================================
 
 # Include test setup functions
-include(${CMAKE_SOURCE_DIR}/cmake/TestSetup.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/TestSetup.cmake)
 
 # Adding regression tests
 #

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -43,36 +43,36 @@ include(${PROJECT_SOURCE_DIR}/cmake/TestSetup.cmake)
 # Calculate pi example
 list(APPEND TEST_DIRS calculate_pi)
 list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
-list(APPEND TEST_ARGS "--driver ${CMAKE_BINARY_DIR}/example/calculate_pi/pi-example \
+list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/calculate_pi/pi-example \
 --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/calculate_pi/parthinput.regression")
 
 # Advection test 
 list(APPEND TEST_DIRS advection_convergence)
 list(APPEND TEST_PROCS "1")
-list(APPEND TEST_ARGS "--driver ${CMAKE_BINARY_DIR}/example/advection/advection-example \
+list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
 --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/advection_convergence/parthinput.advection \
 --num_steps 25")
 
 # Performance regression test
 list(APPEND TEST_DIRS advection_performance)
 list(APPEND TEST_PROCS "1")
-list(APPEND TEST_ARGS "--driver ${CMAKE_BINARY_DIR}/example/advection/advection-example \
+list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
 --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/advection_performance/parthinput.advection_performance \
 --num_steps 5")
 
 if (ENABLE_HDF5)
-  setup_test( output_hdf5 "--driver ${CMAKE_BINARY_DIR}/example/advection/advection-example \
+  setup_test( output_hdf5 "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
   --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/output_hdf5/parthinput.advection \
   --num_steps 4")
-  setup_test_coverage( output_hdf5 "--driver ${CMAKE_BINARY_DIR}/example/advection/advection-example \
+  setup_test_coverage( output_hdf5 "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
   --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/output_hdf5/parthinput.advection \
   --num_steps 4")
   setup_test_mpi( "${NUM_MPI_PROC_TESTING}" output_hdf5
-  "--driver ${CMAKE_BINARY_DIR}/example/advection/advection-example \
+    "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
   --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/output_hdf5/parthinput.advection \
   --num_steps 4")
   setup_test_mpi_coverage("${NUM_MPI_PROC_TESTING}" output_hdf5
-  "--driver ${CMAKE_BINARY_DIR}/example/advection/advection-example \
+    "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
   --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/output_hdf5/parthinput.advection \
   --num_steps 4")
 endif()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Fixes an incorrect cmake variable that uses the wrong path when parthenon is included as a submodule. https://github.com/lanl/parthenon/issues/233
<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
