### PR TITLE
Document ParArrayND Typecasting, Closes #143

### DIFF
--- a/docs/parthenon_arrays.md
+++ b/docs/parthenon_arrays.md
@@ -88,7 +88,7 @@ A `Kokkos::View` with the dimensionality you want can be extracted
 with `ParArrayND.Get<D>();`. This returns a rank-D view. Dimensions
 higher than D are set to zero.
 
-#### Type Subtleties with `ParArrayND.Get`
+#### Type Subtleties
 
 Note that the type returned by `ParArrayND.Get<D>()` is not not a
 simple type. For example, the type returned by `ParArrayND<Real>.Get<4>();` is:


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

A while ago, @pgrete found some unintuitive, but correct, behaviour for `ParArrayND` when it is typecast. I documented this in issue #143. I don't think the code needs to change, but @AndrewGaspar suggested documenting the behavior in the docs and pointing to the issue. I agree. This MR implements that documentation.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint (no new code)
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features. (no bugs or features)
- [x] Code is formatted (no code to format)
