### PR TITLE
WIP: Add -gpu flag for Spectrum MPI and run serial tests under mpiexec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,16 @@ if (NOT PARTHENON_DISABLE_MPI)
   set(ENABLE_MPI ON)
 endif()
 
+execute_process(
+  COMMAND ${MPIEXEC_EXECUTABLE} --version
+  OUTPUT_VARIABLE MPIEXEC_VERSION_RAW
+)
+
+if (MPIEXEC_VERSION_RAW MATCHES "mpiexec \\(IBM Spectrum MPI\\)")
+  message(STATUS "Using IBM Spectrum MPI")
+  set(MPI_IMPLEMENTATION "Spectrum")
+endif()
+
 set(ENABLE_OPENMP OFF)
 if (NOT PARTHENON_DISABLE_OPENMP)
   find_package(OpenMP COMPONENTS CXX)
@@ -192,6 +202,11 @@ elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos/CMakeLists.txt)
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos Kokkos)
 else()
   find_package(Kokkos 3 REQUIRED)
+endif()
+
+if (Kokkos_ENABLE_CUDA AND MPI_IMPLEMENTATION STREQUAL "Spectrum")
+  # Cuda awareness must be explicitly enabled for Spectrum builds builds
+  set(MPIEXEC_PREFLAGS "${MPIEXEC_PREFLAGS} -gpu")
 endif()
 
 # Build Tests and download Catch2

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -30,8 +30,16 @@ endfunction()
 # test output will be sent to /tst/regression/outputs/dir
 # test property labels: regression, mpi-no
 function(setup_test dir arg)
-  separate_arguments(arg) 
-  add_test( NAME regression_test:${dir} COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/run_test.py" 
+  separate_arguments(arg)
+  if (ENABLE_MPI AND MPI_IMPLEMENTATION STREQUAL "Spectrum")
+    # Spectrum MPI requires all MPI programs to be run under mpiexec
+    set(ADDITIONAL_ARGS
+      --mpirun ${MPIEXEC_EXECUTABLE}
+      --mpirun_opts=${MPIEXEC_NUMPROC_FLAG} --mpirun_opts=1
+      --mpirun_opts=${MPIEXEC_PREFLAGS})
+  endif()
+  add_test( NAME regression_test:${dir} COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/run_test.py"
+    ${ADDITIONAL_ARGS}
     ${arg} --test_dir "${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}"
     --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}")
   set_tests_properties(regression_test:${dir} PROPERTIES LABELS "regression;mpi-no" )


### PR DESCRIPTION
## PR Summary

This PR fixes some small issues when running Parthenon's tests with Spectrum MPI. Mainly, it applies the `-gpu` flag to `mpiexec`. It also runs the serial tests under `mpiexec`, as Spectrum MPI requires that.

## PR Checklist

- [x] Code passes cpplint (No C++ changes)
- [x] New features are documented. (No new features)
- [x] Adds a test for any bugs fixed. Adds tests for new features. (Fixes some tests)
- [x] Code is formatted (No C++ changes)
